### PR TITLE
Port flamedisx to tensorflow

### DIFF
--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -219,11 +219,13 @@ class ERSource:
             # make sure output is tensor (or tuple of tensors)
             if isinstance(res, tuple):
                 return tuple([v
-                              if tf.is_tensor(v)
+                              if isinstance(v, tf.Tensor)
                               else tf.convert_to_tensor(v, dtype=tf.float32)
                               for v in res])
             else:
-                return res if tf.is_tensor(res) else tf.convert_to_tensor(res, dtype=tf.float32)
+                return (res
+                        if isinstance(res, tf.Tensor)
+                        else tf.convert_to_tensor(res, dtype=tf.float32))
 
 
     def annotate_data(self, data, max_sigma=3, **params):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -184,7 +184,8 @@ class ERSource:
             if fname in self.tensor_data.keys():
                 args = [v[self.batch_slice] for v in self.tensor_data[fname]]
             else:
-                args = list(data[self.f_dims[fname]].values.T[..., self.batch_slice])
+                # args = list(data[self.f_dims[fname]].values.T[..., self.batch_slice])
+                args = [data[x].values[self.batch_slice] for x in self.f_dims[fname]]
             if bonus_arg is not None:
                 args = [bonus_arg] + args
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -401,7 +401,7 @@ class ERSource:
         pel = self.gimme('p_electron',
                          tf.cast(_nq_1d, dtype=tf.float64))
         pel_fluct = self.gimme('p_electron_fluctuation',
-                               tf.cast(_nq_1d, dtype=tf.float64))
+                               tf.cast(_nq_1d, dtype=tf.float32))
 
         # Create tensors with the dimensions of our final result
         # i.e. (n_events, |photons_produced|, |electrons_produced|),
@@ -441,9 +441,9 @@ class ERSource:
         if quanta_type == 'photon':
             # Note *= doesn't work, p will get reshaped
             p = p * self.gimme('penning_quenching_eff', n_prod)
-        p = tf.convert_to_tensor(p, dtype=tf.float64)
-        result = tfd.Binomial(total_count=tf.cast(n_prod, dtype=tf.float64),
-                              probs=p).prob(tf.cast(n_det, dtype=tf.float64))
+        p = tf.convert_to_tensor(p, dtype=tf.float32)
+        result = tfd.Binomial(total_count=tf.cast(n_prod, dtype=tf.float32),
+                              probs=p).prob(tf.cast(n_det, dtype=tf.float32))
         return result * self.gimme(quanta_type + '_acceptance', n_det)
 
     def domain(self, x):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -428,7 +428,7 @@ class ERSource:
                                             p_mean=pel,
                                             p_sigma=pel_fluct)
         else:
-            pel_num = tf.where(tf.is_nan(pel), tf.zeros_like(pel), pel)
+            pel_num = tf.where(tf.math.is_nan(pel), tf.zeros_like(pel), pel)
             pel_clip = tf.clip_by_value(pel_num, 0., 1.)
             return rate_nq * tfd.Binomial(total_count=nq,
                                           probs=pel_clip).prob(nel)

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -464,7 +464,7 @@ class ERSource:
             return rate_nq * beta_binom_pmf(nel,
                                             n=nq,
                                             p_mean=pel_clip,
-                                            p_sigma=pel_fluct)
+                                            p_sigma=pel_fluct_clip)
         else:
             return rate_nq * tfd.Binomial(total_count=nq,
                                           probs=pel_clip).prob(nel)

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -329,7 +329,7 @@ class ERSource:
         for fname, v in self.f_dims.items():
             self.tensor_data[fname] = [tf.convert_to_tensor(d[x]) for x in v]
         for fname in ['s1', 's2']:
-            self.tensor_data[fname] = tf.convert_to_tensor(d[fname])
+            self.tensor_data[fname] = tf.convert_to_tensor(d[fname], dtype=tf.float32)
 
     def likelihood(self, data=None, max_sigma=3, batch_size=10,
                    progress=lambda x: x, **params):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -382,12 +382,11 @@ class ERSource:
 
         # (n_events, |ne|) tensors
         es, rate_e = self.gimme('energy_spectrum')
-        q_produced = tf.cast(tf.floor(es / self.gimme('work')[:, o]),
-                             dtype=tf.int32)
+        q_produced = tf.floor(es / self.gimme('work')[:, o])
 
         # (n_events, |nq|, |ne|) tensor giving p(nq | e)
         p_nq_e = tf.cast(tf.equal(nq_1d[:, :, o], q_produced[:, o, :]),
-                         dtype=tf.float64)
+                         dtype=tf.float32)
 
         return tf.reduce_sum(p_nq_e * rate_e[:, o, :], axis=2)
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -76,7 +76,7 @@ class ERSource:
 
     def energy_spectrum_hist(self):
         # TODO: fails if e is pos/time dependent
-        es, rs = self.gimme('energy_spectrum').numpy()
+        es, rs = self.gimme('energy_spectrum', numpy=True)
         return Hist1d.from_histogram(rs[0, :-1], es[0, :])
 
     def simulate_es(self, n):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -567,7 +567,10 @@ class ERSource:
         d = d.sample(n=len(energies), replace=True)
 
         def gimme(*args):
-            return self.gimme(*args, data=d, params=params)
+            return self.gimme(*args,
+                              data=d,
+                              params=params,
+                              numpy_out=True)
 
         d['energy'] = energies
         self.simulate_nq(data=d, params=params)
@@ -603,10 +606,9 @@ class ERSource:
 
         acceptance = np.ones(len(d))
         for q in quanta_types:
-            acceptance *= gimme(q + '_acceptance',
-                                d[q + '_detected'], numpy_out=True)
+            acceptance *= gimme(q + '_acceptance', d[q + '_detected'])
             sn = signal_name[q]
-            acceptance *= gimme(sn + '_acceptance', d[sn], numpy_out=True)
+            acceptance *= gimme(sn + '_acceptance', d[sn])
         d = d.iloc[np.random.rand(len(d)) < acceptance]
         return d
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -556,7 +556,6 @@ class ERSource:
             params = self._params
         if data is None:
             data = self.data
-        self.set_data(data, **params)
 
         if isinstance(energies, (float, int)):
             energies = self.simulate_es(int(energies))
@@ -564,6 +563,8 @@ class ERSource:
         # Keep only dims we need
         d = data[list(set(sum(self.f_dims.values(), [])))]
         d = d.sample(n=len(energies), replace=True)
+
+        self.set_data(data, **params)
 
         def gimme(*args):
             return self.gimme(*args,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -342,13 +342,12 @@ class ERSource:
         # Evaluate in batches to save memory
         n_batches = np.ceil(len(self.data[self.batch_slice]) / batch_size).astype(np.int)
         if n_batches > 1:
-            # orig_data = self.data
+            orig_data = self.data
             result = []
             for i in progress(list(range(n_batches))):
                 self.batch_slice = slice(i * batch_size,
                                          (i + 1) * batch_size)
-                # self.data = orig_data[
-                #             i * batch_size:(i + 1) * batch_size].copy()
+                self.data = orig_data[self.batch_slice].copy()
                 result.append(self.likelihood(**params))
             return np.concatenate(result)
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -220,11 +220,15 @@ class ERSource:
         else:
             # make sure output is tensor (or tuple of tensors)
             if isinstance(res, tuple):
+                if not isinstance(res[0], np.ndarray):
+                    [assert v.dtype is tf.float32 for v in res]
                 return tuple([v
                               if isinstance(v, tf.Tensor)
                               else tf.convert_to_tensor(v, dtype=tf.float32)
                               for v in res])
             else:
+                if not isinstance(res, np.ndarray):
+                    assert res.dtype is tf.float32
                 return (res
                         if isinstance(res, tf.Tensor)
                         else tf.convert_to_tensor(res, dtype=tf.float32))

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -186,6 +186,7 @@ class ERSource:
 
         if callable(f):
             if fname in self.tensor_data.keys():
+                print('Woop woop')
                 args = [v for v in self.tensor_data[fname]]
             else:
                 args = [data[x].values for x in self.f_dims[fname]]

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -430,7 +430,7 @@ class ERSource:
         else:
             pel_num = tf.where(tf.math.is_nan(pel), tf.zeros_like(pel), pel)
             pel_clip = tf.clip_by_value(pel_num, 0., 1.)
-            return rate_nq * tfd.Binomial(total_count=nq,
+            return rate_nq * tfd.Binomial(total_count=tf.cast(nq, dtype=tf.float32),
                                           probs=pel_clip).prob(nel)
 
     def detection_p(self, quanta_type):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -204,6 +204,7 @@ class ERSource:
             if isinstance(res, np.ndarray):
                 return res
             return res.numpy()
+        return res
 
     def annotate_data(self, data, max_sigma=3, **params):
         """Annotate data with columns needed or inference,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -611,7 +611,7 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     code. Should we have [x, n-x] or [n-x, x]?
     """
     beta_pars = tf.stack(beta_params(p_mean, p_sigma), axis=-1)
-    counts = tf.cast(tf.stack([x, n-x], axis=-1), dtype=tf.float64)
+    counts = tf.cast(tf.stack([x, n-x], axis=-1), dtype=tf.float32)
     res = tfd.DirichletMultinomial(tf.cast(n, dtype=tf.float32),
                                    beta_pars,
                                    allow_nan_stats=False).prob(counts)

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -200,9 +200,11 @@ class ERSource:
             res = f(*args, **kwargs)
         else:
             if bonus_arg is None:
-                res = f * tf.ones(len(data))[self.batch_slice]
+                res = f * tf.ones(len(data),
+                                  dtype=tf.float32)[self.batch_slice]
             else:
-                res = f * tf.ones_like(bonus_arg)[self.batch_slice]
+                res = f * tf.ones_like(bonus_arg,
+                                       dtype=tf.float32)[self.batch_slice]
 
         # Convert to numpy array if numpy_out else output tensor
         if numpy_out:

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -655,13 +655,19 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     TODO: check if the number of successes wasn't reversed in the original
     code. Should we have [x, n-x] or [n-x, x]?
     """
+    # Test float64
+    x = tf.cast(x, dtype=tf.float64)
+    n = tf.cast(n, dtype=tf.float64)
+    p_mean = tf.cast(p_mean, dtype=tf.float64)
+    p_sigma = tf.cast(p_sigma, dtype=tf.float64)
+
     beta_pars = tf.stack(beta_params(p_mean, p_sigma), axis=-1)
-    counts = tf.cast(tf.stack([x, n-x], axis=-1), dtype=tf.int32)
-    n = tf.cast(n, dtype=tf.int32)
+    counts = tf.stack([x, n-x], axis=-1)
     res = tfd.DirichletMultinomial(n,
                                    beta_pars,
                                    validate_args=True,
                                    allow_nan_stats=False).prob(counts)
+    res = tf.cast(res, dtype=tf.float32)
     return tf.where(tf.math.is_finite(res),
                     res,
                     tf.zeros_like(res, dtype=tf.float32))

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -93,7 +93,7 @@ class ERSource:
 
     @staticmethod
     def penning_quenching_eff(nph):
-        return tf.ones_like(nph)
+        return tf.ones_like(nph, dtype=tf.float32)
 
     # Detection efficiencies
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -328,7 +328,7 @@ class ERSource:
 
         # Precompute tensors for use in gimme
         for fname, v in self.f_dims.items():
-            self.tensor_data[fname] = [tf.convert_to_tensor(d[x]) for x in v]
+            self.tensor_data[fname] = [tf.convert_to_tensor(d[x], dtype=tf.float32) for x in v]
         for fname in ['s1', 's2']:
             self.tensor_data[fname] = tf.convert_to_tensor(d[fname], dtype=tf.float32)
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -70,9 +70,8 @@ class ERSource:
         """
         # TODO: doesn't depend on drift_time...
         n_evts = len(drift_time)
-        return (
-            np.linspace(0, 10, 1000)[o, :].repeat(n_evts, axis=0),
-            np.ones(1000)[o, :].repeat(n_evts, axis=0))
+        return (repeat(tf.linspace(0, 10, 1000)[o, :], n_evts, axis=0),
+                repeat(tf.ones(1000)[o, :], n_evts, axis=0))
 
     def energy_spectrum_hist(self):
         # TODO: fails if e is pos/time dependent
@@ -99,33 +98,39 @@ class ERSource:
     # Detection efficiencies
 
     @staticmethod
-    def electron_detection_eff(drift_time, *, elife=600e3, extraction_eff=1):
-        return extraction_eff * np.exp(-drift_time / elife)
+    def electron_detection_eff(drift_time, *, elife=600e3, extraction_eff=1.):
+        return extraction_eff * tf.exp(-drift_time / elife)
 
     photon_detection_eff = 0.1
 
     # Acceptance of selection/detection on photons/electrons detected
 
-    electron_acceptance = 1
+    electron_acceptance = 1.
 
     @staticmethod
     def photon_acceptance(photons_detected):
-        return np.where(photons_detected < 3, 0, 1)
+        return tf.where(photons_detected < 3,
+                        tf.zeros_like(photons_detected),
+                        tf.ones_like(photons_detected))
 
     # Acceptance of selections on S1/S2 directly
 
     @staticmethod
     def s1_acceptance(s1):
-        return np.where(s1 < 2, 0, 1)
+        return tf.where(s1 < 2,
+                        tf.zeros_like(s1),
+                        tf.ones_like(s1))
 
     @staticmethod
     def s2_acceptance(s2):
-        return np.where(s2 < 200, 0, 1)
+        return tf.where(s2 < 200,
+                        tf.zeros_like(s2),
+                        tf.ones_like(s2))
 
-    electron_gain_mean = 20
-    electron_gain_std = 5
+    electron_gain_mean = 20.
+    electron_gain_std = 5.
 
-    photon_gain_mean = 1
+    photon_gain_mean = 1.
     photon_gain_std = 0.5
     double_pe_fraction = 0.219
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -603,9 +603,10 @@ class ERSource:
 
         acceptance = np.ones(len(d))
         for q in quanta_types:
-            acceptance *= gimme(q + '_acceptance', d[q + '_detected'])
+            acceptance *= gimme(q + '_acceptance',
+                                d[q + '_detected'], numpy_out=True)
             sn = signal_name[q]
-            acceptance *= gimme(sn + '_acceptance', d[sn])
+            acceptance *= gimme(sn + '_acceptance', d[sn], numpy_out=True)
         d = d.iloc[np.random.rand(len(d)) < acceptance]
         return d
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -436,10 +436,7 @@ class ERSource:
         _nq_1d = self.domain('nq')
         rate_nq = self.rate_nq(_nq_1d)
         pel = self.gimme('p_electron', _nq_1d)
-        pel_fluct = tf.clip_by_value(self.gimme('p_electron_fluctuation',
-                                                _nq_1d),
-                                     1e-6,
-                                     1.)
+        pel_fluct = self.gimme('p_electron_fluctuation', _nq_1d)
 
         # Create tensors with the dimensions of our final result
         # i.e. (n_events, |photons_produced|, |electrons_produced|),
@@ -462,6 +459,7 @@ class ERSource:
                            tf.zeros_like(pel, dtype=tf.float32),
                            pel)
         pel_clip = tf.clip_by_value(pel_num, 0., 1.)
+        pel_fluct_clip = tf.clip_by_value(pel_fluct, 1e-6, 1.)
         if self.do_pel_fluct:
             return rate_nq * beta_binom_pmf(nel,
                                             n=nq,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -639,8 +639,8 @@ class NRSource(ERSource):
         """Return (energies in keV, events at these energies),
         both (n_events, n_energies) tensors.
         """
-        e = np.linspace(0.7, 150, 100)[o, :].repeat(len(drift_time), axis=0)
-        return e, np.ones_like(e)
+        e = repeat(tf.linspace(0.7, 150, 100)[o, :], len(drift_time), axis=0)
+        return e, tf.ones_like(e)
 
     def rate_nq(self, nq_1d):
         # (n_events, |ne|) tensors
@@ -651,10 +651,9 @@ class NRSource(ERSource):
                 / self.gimme('work')[:, o])
 
         # (n_events, |nq|, |ne|) tensor giving p(nq | e)
-        p_nq_e = stats.poisson.pmf(nq_1d[:, :, o],
-                                   mean_q_produced[:, o, :])
+        p_nq_e = tfd.Poisson(mean_q_produced[:, o, :]).prob(nq_1d[:, :, o])
 
-        return (p_nq_e * rate_e[:, o, :]).sum(axis=2)
+        return tf.reduce_sum(p_nq_e * rate_e[:, o, :], axis=2)
 
     @staticmethod
     def penning_quenching_eff(nph, eta=8.2e-5 * 3.3, labda=0.8 * 1.15):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -48,7 +48,8 @@ def _lookup_axis1(x, indices, fill_value=0):
     result = tf.reshape(tf.gather(x,
                                   tf.reshape(indices, shape=(-1,))),
                         shape=indices.shape)
-    return tf.where(mask, result, tf.zeros_like(result) + fill_value)
+    return tf.cast(tf.where(mask, result, tf.zeros_like(result) + fill_value),
+                   dtype=tf.float32)
 
 
 class ERSource:

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -436,7 +436,10 @@ class ERSource:
         _nq_1d = self.domain('nq')
         rate_nq = self.rate_nq(_nq_1d)
         pel = self.gimme('p_electron', _nq_1d)
-        pel_fluct = self.gimme('p_electron_fluctuation', _nq_1d)
+        pel_fluct = tf.clip_by_value(self.gimme('p_electron_fluctuation',
+                                                _nq_1d),
+                                     1e-6,
+                                     1.)
 
         # Create tensors with the dimensions of our final result
         # i.e. (n_events, |photons_produced|, |electrons_produced|),

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -75,8 +75,8 @@ class ERSource:
 
     def energy_spectrum_hist(self):
         # TODO: fails if e is pos/time dependent
-        es, rs = self.gimme('energy_spectrum')
-        return Hist1d.from_histogram(rs.numpy()[0, :-1], es.numpy()[0, :])
+        es, rs = self.gimme('energy_spectrum', numpy_out=True)
+        return Hist1d.from_histogram(rs[0, :-1], es[0, :])
 
     def simulate_es(self, n):
         return self.energy_spectrum_hist().get_random(n)
@@ -674,7 +674,8 @@ class NRSource(ERSource):
         """Return Lindhard quenching factor at energy e in keV"""
         eps = 11.5 * e * 54**(-7/3)             # Xenon: Z = 54
         g = 3. * eps**0.15 + 0.7 * eps**0.6 + eps
-        return lindhard_k * g/(1 + lindhard_k * g)
+        res = lindhard_k * g/(1. + lindhard_k * g)
+        return tf.convert_to_tensor(res, dtype=tf.float32)
 
     def energy_spectrum(self, drift_time):
         """Return (energies in keV, events at these energies),

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -612,7 +612,7 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     """
     beta_pars = tf.stack(beta_params(p_mean, p_sigma), axis=-1)
     counts = tf.cast(tf.stack([x, n-x], axis=-1), dtype=tf.float64)
-    res = tfd.DirichletMultinomial(tf.cast(n, dtype=tf.float64),
+    res = tfd.DirichletMultinomial(tf.cast(n, dtype=tf.float32),
                                    beta_pars,
                                    allow_nan_stats=False).prob(counts)
     return tf.where(tf.math.is_finite(res), res, tf.zeros_like(res))

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -70,7 +70,7 @@ class ERSource:
         """
         # TODO: doesn't depend on drift_time...
         n_evts = len(drift_time)
-        return (repeat(tf.linspace(0, 10, 1000)[o, :], n_evts, axis=0),
+        return (repeat(tf.linspace(0., 10., 1000)[o, :], n_evts, axis=0),
                 repeat(tf.ones(1000)[o, :], n_evts, axis=0))
 
     def energy_spectrum_hist(self):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -557,6 +557,8 @@ class ERSource:
         if data is None:
             data = self.data
 
+        self.set_data(data, **params)
+
         if isinstance(energies, (float, int)):
             energies = self.simulate_es(int(energies))
 
@@ -564,7 +566,7 @@ class ERSource:
         d = data[list(set(sum(self.f_dims.values(), [])))]
         d = d.sample(n=len(energies), replace=True)
 
-        self.set_data(data, **params)
+        self.set_data(d, **params)
 
         def gimme(*args):
             return self.gimme(*args,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -656,7 +656,8 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     code. Should we have [x, n-x] or [n-x, x]?
     """
     beta_pars = tf.stack(beta_params(p_mean, p_sigma), axis=-1)
-    counts = tf.stack([x, n-x], axis=-1)
+    counts = tf.cast(tf.stack([x, n-x], axis=-1), dtype=tf.int32)
+    n = tf.cast(n, dtype=tf.int32)
     res = tfd.DirichletMultinomial(n,
                                    beta_pars,
                                    validate_args=True,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -76,7 +76,7 @@ class ERSource:
 
     def energy_spectrum_hist(self):
         # TODO: fails if e is pos/time dependent
-        es, rs = self.gimme('energy_spectrum')
+        es, rs = self.gimme('energy_spectrum').numpy()
         return Hist1d.from_histogram(rs[0, :-1], es[0, :])
 
     def simulate_es(self, n):
@@ -86,15 +86,15 @@ class ERSource:
 
     @staticmethod
     def p_electron(nq):
-        return 0.5 * np.ones_like(nq)
+        return 0.5 * tf.ones_like(nq)
 
     @staticmethod
     def p_electron_fluctuation(nq):
-        return 0.01 * np.ones_like(nq)
+        return 0.01 * tf.ones_like(nq)
 
     @staticmethod
     def penning_quenching_eff(nph):
-        return np.ones_like(nph)
+        return tf.ones_like(nph)
 
     # Detection efficiencies
 
@@ -196,8 +196,8 @@ class ERSource:
 
         else:
             if bonus_arg is None:
-                return f * np.ones(len(data))[self.batch_slice]
-            return f * np.ones_like(bonus_arg)
+                return f * tf.ones(len(data))[self.batch_slice]
+            return f * tf.ones_like(bonus_arg)[self.batch_slice]
 
     def annotate_data(self, data, max_sigma=3, **params):
         """Annotate data with columns needed or inference,
@@ -229,8 +229,8 @@ class ERSource:
         for qn in quanta_types:
             for parname in hidden_vars_per_quanta:
                 fname = qn + '_' + parname
-                d[fname] = self.gimme(fname)
-        d['double_pe_fraction'] = self.gimme('double_pe_fraction')
+                d[fname] = self.gimme(fname).numpy()
+        d['double_pe_fraction'] = self.gimme('double_pe_fraction').numpy()
 
         # Find likely number of detected quanta
         obs = dict(photon=d['s1'], electron=d['s2'])
@@ -247,7 +247,7 @@ class ERSource:
         # TODO: this will fail when someone gives penning quenching some
         # data-dependent args
         _nprod_temp = np.logspace(-1, 8, 1000)
-        peff = self.gimme('penning_quenching_eff', _nprod_temp)
+        peff = self.gimme('penning_quenching_eff', _nprod_temp).numpy()
         d['penning_quenching_eff_mle'] = np.interp(
             d['photon_detected_mle'] / d['photon_detection_eff'],
             _nprod_temp * peff,
@@ -259,8 +259,8 @@ class ERSource:
             d['electron_detected_mle'] / d['electron_detection_eff']
             + (d['photon_detected_mle'] / d['photon_detection_eff']
                / d['penning_quenching_eff_mle']))
-        d['e_vis'] = self.gimme('work') * d['nq_vis_mle']
-        d['fel_mle'] = self.gimme('p_electron', d['nq_vis_mle'])
+        d['e_vis'] = self.gimme('work').numpy() * d['nq_vis_mle']
+        d['fel_mle'] = self.gimme('p_electron', d['nq_vis_mle']).numpy()
 
         # Find plausble ranges for detected and observed quanta
         # based on the observed S1 and S2 sizes

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -342,12 +342,10 @@ class ERSource:
         # Evaluate in batches to save memory
         n_batches = np.ceil(len(self.data[self.batch_slice]) / batch_size).astype(np.int)
         if n_batches > 1:
-            orig_data = self.data
             result = []
             for i in progress(list(range(n_batches))):
                 self.batch_slice = slice(i * batch_size,
                                          (i + 1) * batch_size)
-                self.data = orig_data[self.batch_slice].copy()
                 result.append(self.likelihood(**params))
             return np.concatenate(result)
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -431,7 +431,7 @@ class ERSource:
             pel_num = tf.where(tf.math.is_nan(pel), tf.zeros_like(pel), pel)
             pel_clip = tf.clip_by_value(pel_num, 0., 1.)
             return rate_nq * tfd.Binomial(total_count=tf.cast(nq, dtype=tf.float32),
-                                          probs=pel_clip).prob(nel)
+                                          probs=pel_clip).prob(tf.cast(nel, dtype=tf.float32))
 
     def detection_p(self, quanta_type):
         """Return (n_events, |detected|, |produced|) tensor

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -364,9 +364,9 @@ class ERSource:
 
         # Precompute tensors for use in gimme
         for fname, v in self.f_dims.items():
-            self.tensor_data[fname] = [tf.convert_to_tensor(d[x], dtype=tf.float32) for x in v]
+            self.tensor_data[fname] = [tf.convert_to_tensor(d[x].values, dtype=tf.float32) for x in v]
         for fname in ['s1', 's2']:
-            self.tensor_data[fname] = tf.convert_to_tensor(d[fname], dtype=tf.float32)
+            self.tensor_data[fname] = tf.convert_to_tensor(d[fname].values, dtype=tf.float32)
 
     def likelihood(self, data=None, max_sigma=3, **params):
         self._params = params

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -443,7 +443,8 @@ class ERSource:
             p = p * self.gimme('penning_quenching_eff', n_prod)
 
         result = tfd.Binomial(total_count=n_prod,
-                              probs=p).prob(n_det)
+                              probs=tf.cast(p, dtype=tf.float32),
+                              ).prob(n_det)
         return result * self.gimme(quanta_type + '_acceptance', n_det)
 
     def domain(self, x):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -637,6 +637,9 @@ def beta_params(mean, sigma):
     # =>
     # beta = (1/variance - 4) / 8
     # alpha
+    mean = tf.cast(mean, dtype=tf.float64)
+    sigma = tf.cast(sigma, dtype=tf.float64)
+
     b = (1. / (8. * sigma ** 2) - 0.5)
     a = b * mean / (1. - mean)
     return a, b
@@ -656,18 +659,20 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     code. Should we have [x, n-x] or [n-x, x]?
     """
     # Test float64
-    x = tf.cast(x, dtype=tf.float64)
-    n = tf.cast(n, dtype=tf.float64)
-    p_mean = tf.cast(p_mean, dtype=tf.float64)
-    p_sigma = tf.cast(p_sigma, dtype=tf.float64)
+    # x = tf.cast(x, dtype=tf.float64)
+    # n = tf.cast(n, dtype=tf.float64)
+    # p_mean = tf.cast(p_mean, dtype=tf.float64)
+    # p_sigma = tf.cast(p_sigma, dtype=tf.float64)
 
     beta_pars = tf.stack(beta_params(p_mean, p_sigma), axis=-1)
+    beta_pars = tf.cast(beta_pars, dtype=tf.float32)
+
     counts = tf.stack([x, n-x], axis=-1)
     res = tfd.DirichletMultinomial(n,
                                    beta_pars,
                                    validate_args=True,
                                    allow_nan_stats=False).prob(counts)
-    res = tf.cast(res, dtype=tf.float32)
+    #res = tf.cast(res, dtype=tf.float32)
     return tf.where(tf.math.is_finite(res),
                     res,
                     tf.zeros_like(res, dtype=tf.float32))

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -563,7 +563,7 @@ class ERSource:
             energies = self.simulate_es(int(energies))
 
         # Keep only dims we need
-        d = data[list(set(sum(self.f_dims.values(), [])))]
+        d = data[list(set(sum(self.f_dims.values(), []))) + ['s1', 's2']]
         d = d.sample(n=len(energies), replace=True)
 
         self.set_data(d, **params)
@@ -610,6 +610,7 @@ class ERSource:
             sn = signal_name[q]
             acceptance *= gimme(sn + '_acceptance', d[sn].values)
         d = d.iloc[np.random.rand(len(d)) < acceptance]
+        self.set_data(d, **params)
         return d
 
     def simulate_nq(self, data, params):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -399,7 +399,7 @@ class ERSource:
         _nq_1d = self.domain('nq')
         rate_nq = self.rate_nq(_nq_1d)
         pel = self.gimme('p_electron',
-                         tf.cast(_nq_1d, dtype=tf.float64))
+                         tf.cast(_nq_1d, dtype=tf.float32))
         pel_fluct = self.gimme('p_electron_fluctuation',
                                tf.cast(_nq_1d, dtype=tf.float32))
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -186,7 +186,6 @@ class ERSource:
 
         if callable(f):
             if fname in self.tensor_data.keys():
-                print('Woop woop')
                 args = [v for v in self.tensor_data[fname]]
             else:
                 args = [data[x].values for x in self.f_dims[fname]]
@@ -248,12 +247,14 @@ class ERSource:
             self.data = old_data
             self._params = old_params
 
-    def set_data(self, data, max_sigma=3):
+    def set_data(self, data, max_sigma=3, **params):
         # remove any previously computed tensors
         self.tensor_data = dict()
         # Set new data
         self.data = d = data
 
+
+        self._params = params
         # TODO precompute energy spectra for each event?
 
         # Annotate data with eff, mean, sigma
@@ -555,6 +556,7 @@ class ERSource:
             params = self._params
         if data is None:
             data = self.data
+        self.set_data(data, **params)
 
         if isinstance(energies, (float, int)):
             energies = self.simulate_es(int(energies))
@@ -565,8 +567,6 @@ class ERSource:
 
         def gimme(*args):
             return self.gimme(*args,
-                              data=d,
-                              params=params,
                               numpy_out=True)
 
         d['energy'] = energies

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -458,7 +458,7 @@ class ERSource:
         pel_num = tf.where(tf.math.is_nan(pel),
                            tf.zeros_like(pel, dtype=tf.float32),
                            pel)
-        pel_clip = tf.clip_by_value(pel_num, 0., 1.)
+        pel_clip = tf.clip_by_value(pel_num, 1e-6, 1. - 1e-6)
         pel_fluct_clip = tf.clip_by_value(pel_fluct, 1e-6, 1.)
         if self.do_pel_fluct:
             return rate_nq * beta_binom_pmf(nel,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -294,7 +294,7 @@ class ERSource:
             + (d['photon_detected_mle'] / d['photon_detection_eff']
                / d['penning_quenching_eff_mle']))
         d['e_vis'] = self.gimme('work', numpy_out=True) * d['nq_vis_mle']
-        d['fel_mle'] = self.gimme('p_electron', d['nq_vis_mle'],
+        d['fel_mle'] = self.gimme('p_electron', d['nq_vis_mle'].values,
                                   numpy_out=True)
 
         # Find plausble ranges for detected and observed quanta

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -221,7 +221,8 @@ class ERSource:
             # make sure output is tensor (or tuple of tensors)
             if isinstance(res, tuple):
                 if not isinstance(res[0], np.ndarray):
-                    [assert v.dtype is tf.float32 for v in res]
+                    for v in res:
+                        assert v.dtype is tf.float32
                 return tuple([v
                               if isinstance(v, tf.Tensor)
                               else tf.convert_to_tensor(v, dtype=tf.float32)

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -466,7 +466,8 @@ class ERSource:
         """Return (n_events, |n_detected|) probability of observing the S[1|2]
         for different number of detected quanta.
         """
-        ndet = self.domain(quanta_type + '_detected')
+        ndet = tf.cast(self.domain(quanta_type + '_detected'),
+                       dtype=tf.float64)
 
         observed = self.data[signal_name[quanta_type]].values[:, o]
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -71,7 +71,7 @@ class ERSource:
         # TODO: doesn't depend on drift_time...
         n_evts = len(drift_time)
         return (repeat(tf.linspace(0., 10., 1000)[o, :], n_evts, axis=0),
-                repeat(tf.ones(1000)[o, :], n_evts, axis=0))
+                repeat(tf.ones(1000, dtype=tf.float32)[o, :], n_evts, axis=0))
 
     def energy_spectrum_hist(self):
         # TODO: fails if e is pos/time dependent
@@ -85,11 +85,11 @@ class ERSource:
 
     @staticmethod
     def p_electron(nq):
-        return 0.5 * tf.ones_like(nq)
+        return 0.5 * tf.ones_like(nq, dtype=tf.float32)
 
     @staticmethod
     def p_electron_fluctuation(nq):
-        return 0.01 * tf.ones_like(nq)
+        return 0.01 * tf.ones_like(nq, dtype=tf.float32)
 
     @staticmethod
     def penning_quenching_eff(nph):
@@ -110,22 +110,22 @@ class ERSource:
     @staticmethod
     def photon_acceptance(photons_detected):
         return tf.where(photons_detected < 3,
-                        tf.zeros_like(photons_detected),
-                        tf.ones_like(photons_detected))
+                        tf.zeros_like(photons_detected, dtype=tf.float32),
+                        tf.ones_like(photons_detected, dtype=tf.float32))
 
     # Acceptance of selections on S1/S2 directly
 
     @staticmethod
     def s1_acceptance(s1):
         return tf.where(s1 < 2,
-                        tf.zeros_like(s1),
-                        tf.ones_like(s1))
+                        tf.zeros_like(s1, dtype=tf.float32),
+                        tf.ones_like(s1, dtype=tf.float32))
 
     @staticmethod
     def s2_acceptance(s2):
         return tf.where(s2 < 200,
-                        tf.zeros_like(s2),
-                        tf.ones_like(s2))
+                        tf.zeros_like(s2, dtype=tf.float32),
+                        tf.ones_like(s2, dtype=tf.float32))
 
     electron_gain_mean = 20.
     electron_gain_std = 5.
@@ -629,8 +629,8 @@ def beta_params(mean, sigma):
     # =>
     # beta = (1/variance - 4) / 8
     # alpha
-    b = (1 / (8 * sigma ** 2) - 0.5)
-    a = b * mean / (1 - mean)
+    b = (1. / (8. * sigma ** 2) - 0.5)
+    a = b * mean / (1. - mean)
     return a, b
 
 
@@ -652,7 +652,9 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     res = tfd.DirichletMultinomial(n,
                                    beta_pars,
                                    allow_nan_stats=False).prob(counts)
-    return tf.where(tf.math.is_finite(res), res, tf.zeros_like(res))
+    return tf.where(tf.math.is_finite(res),
+                    res,
+                    tf.zeros_like(res, dtype=tf.float32))
 
 
 class NRSource(ERSource):
@@ -664,7 +666,7 @@ class NRSource(ERSource):
     def lindhard_l(e, lindhard_k=0.138):
         """Return Lindhard quenching factor at energy e in keV"""
         eps = 11.5 * e * 54**(-7/3)             # Xenon: Z = 54
-        g = 3 * eps**0.15 + 0.7 * eps**0.6 + eps
+        g = 3. * eps**0.15 + 0.7 * eps**0.6 + eps
         return lindhard_k * g/(1 + lindhard_k * g)
 
     def energy_spectrum(self, drift_time):

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -428,7 +428,8 @@ class ERSource:
                                             p_mean=pel,
                                             p_sigma=pel_fluct)
         else:
-            pel_clip = np.nan_to_num(pel).clip(0, 1)
+            pel_num = tf.where(tf.is_nan(pel), tf.zeros_like(pel), pel)
+            pel_clip = tf.clip_by_value(pel_num, 0., 1.)
             return rate_nq * tfd.Binomial(total_count=nq,
                                           probs=pel_clip).prob(nel)
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -469,7 +469,7 @@ class ERSource:
         for different number of detected quanta.
         """
         ndet = tf.cast(self.domain(quanta_type + '_detected'),
-                       dtype=tf.float64)
+                       dtype=tf.float32)
 
         observed = self.tensor_data[signal_name[quanta_type]][self.batch_slice, o]
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -382,7 +382,8 @@ class ERSource:
 
         # (n_events, |ne|) tensors
         es, rate_e = self.gimme('energy_spectrum')
-        q_produced = tf.floor(es / self.gimme('work')[:, o])
+        q_produced = tf.cast(tf.floor(es / self.gimme('work')[:, o]),
+                             dtype=tf.float32)
 
         # (n_events, |nq|, |ne|) tensor giving p(nq | e)
         p_nq_e = tf.cast(tf.equal(nq_1d[:, :, o], q_produced[:, o, :]),

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -276,7 +276,7 @@ class ERSource:
         # using interpolation
         # TODO: this will fail when someone gives penning quenching some
         # data-dependent args
-        _nprod_temp = np.logspace(-1, 8, 1000)
+        _nprod_temp = np.logspace(-1., 8., 1000)
         peff = self.gimme('penning_quenching_eff', _nprod_temp, numpy_out=True)
         d['penning_quenching_eff_mle'] = np.interp(
             d['photon_detected_mle'] / d['photon_detection_eff'],
@@ -567,6 +567,8 @@ class ERSource:
         d = d.sample(n=len(energies), replace=True)
 
         def gimme(*args):
+            args = [v.values if isinstance(v, pd.Series) else v
+                    for v in args]
             return self.gimme(*args,
                               data=d,
                               params=params,
@@ -667,8 +669,8 @@ class NRSource(ERSource):
         """Return (energies in keV, events at these energies),
         both (n_events, n_energies) tensors.
         """
-        e = repeat(tf.linspace(0.7, 150, 100)[o, :], len(drift_time), axis=0)
-        return e, tf.ones_like(e)
+        e = repeat(tf.linspace(0.7, 150., 100)[o, :], len(drift_time), axis=0)
+        return e, tf.ones_like(e, dtype=tf.float32)
 
     def rate_nq(self, nq_1d):
         # (n_events, |ne|) tensors
@@ -685,7 +687,7 @@ class NRSource(ERSource):
 
     @staticmethod
     def penning_quenching_eff(nph, eta=8.2e-5 * 3.3, labda=0.8 * 1.15):
-        return 1 / (1 + eta * nph ** labda)
+        return 1. / (1. + eta * nph ** labda)
 
     def simulate_nq(self, data, params):
         work = self.gimme('work',

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -609,7 +609,7 @@ class ERSource:
             acceptance *= gimme(q + '_acceptance', d[q + '_detected'].values)
             sn = signal_name[q]
             acceptance *= gimme(sn + '_acceptance', d[sn].values)
-        d = d.iloc[np.random.rand(len(d)) < acceptance]
+        d = d.iloc[np.random.rand(len(d)) < acceptance].copy()
         self.set_data(d, **params)
         return d
 

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -658,6 +658,7 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     counts = tf.stack([x, n-x], axis=-1)
     res = tfd.DirichletMultinomial(n,
                                    beta_pars,
+                                   validate_args=True,
                                    allow_nan_stats=False).prob(counts)
     return tf.where(tf.math.is_finite(res),
                     res,

--- a/flamedisx/core.py
+++ b/flamedisx/core.py
@@ -328,6 +328,8 @@ class ERSource:
         # Precompute tensors for use in gimme
         for fname, v in self.f_dims.items():
             self.tensor_data[fname] = [tf.convert_to_tensor(d[x]) for x in v]
+        for fname in ['s1', 's2']:
+            self.tensor_data[fname] = tf.convert_to_tensor(d[fname])
 
     def likelihood(self, data=None, max_sigma=3, batch_size=10,
                    progress=lambda x: x, **params):
@@ -469,7 +471,7 @@ class ERSource:
         ndet = tf.cast(self.domain(quanta_type + '_detected'),
                        dtype=tf.float64)
 
-        observed = self.data[signal_name[quanta_type]].values[:, o]
+        observed = self.tensor_data[signal_name[quanta_type]][self.batch_slice, o]
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean')[:, o]

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -2,19 +2,12 @@
 
 """
 import numpy as np
-import tensorflow as tf
 
 from multihist import Hist1d
 import straxen
 import wimprates
 
 from flamedisx import ERSource, NRSource
-
-def make_tensor(func):
-    def inner(*args, **kwargs):
-        return tf.convert_to_tensor(func(*args, **kwargs),
-                                    dtype=tf.float32)
-    return inner
 
 ##
 # Electron probability
@@ -117,13 +110,11 @@ def safe_p(ps):
 class SR0Source:
 
     @staticmethod
-    @make_tensor
     def electron_detection_eff(drift_time,
                                *, elife=452e3, extraction_eff=0.96):
         return extraction_eff * np.exp(-drift_time / elife)
 
     @staticmethod
-    @make_tensor
     def electron_gain_mean(x_observed, y_observed,
                            g2=11.4 / (1 - 0.63) / 0.96):
         return g2 * s2_map(np.transpose([x_observed, y_observed]))
@@ -131,7 +122,6 @@ class SR0Source:
     electron_gain_std = 11.4 * 0.25 / (1 - 0.63)
 
     @staticmethod
-    @make_tensor
     def photon_detection_eff(x, y, z,
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_map(np.transpose([x, y, z]))
@@ -140,12 +130,10 @@ class SR0Source:
 class SR0ERSource(SR0Source, ERSource):
 
     @staticmethod
-    @make_tensor
     def p_electron(nq):
         return safe_p(p_el_thesis(nq * 13.8e-3))
 
     @staticmethod
-    @make_tensor
     def p_electron_fluctuation(nq):
         # q3 = 1.7 keV ~= 123 quanta
         return np.clip(0.041 * (1 - np.exp(-nq/123)), 1e-4, None)
@@ -163,7 +151,6 @@ example_sp = Hist1d.from_histogram(
 
 class SR0NRSource(SR0Source, NRSource):
 
-    @make_tensor
     def energy_spectrum(self, drift_time):
         n_evts = len(drift_time)
         return (
@@ -171,6 +158,5 @@ class SR0NRSource(SR0Source, NRSource):
             example_sp.histogram[np.newaxis,:].repeat(n_evts, axis=0))
 
     @staticmethod
-    @make_tensor
     def p_electron(nq):
         return safe_p(p_electron_nr(nq))

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -2,6 +2,7 @@
 
 """
 import numpy as np
+import tensorflow as tf
 
 from multihist import Hist1d
 import straxen
@@ -9,6 +10,11 @@ import wimprates
 
 from flamedisx import ERSource, NRSource
 
+def make_tensor(func):
+    def inner(*args, **kwargs):
+        return tf.convert_to_tensor(func(*args, **kwargs),
+                                    dtype=tf.float32)
+    return inner
 
 ##
 # Electron probability
@@ -111,11 +117,13 @@ def safe_p(ps):
 class SR0Source:
 
     @staticmethod
+    @make_tensor
     def electron_detection_eff(drift_time,
                                *, elife=452e3, extraction_eff=0.96):
         return extraction_eff * np.exp(-drift_time / elife)
 
     @staticmethod
+    @make_tensor
     def electron_gain_mean(x_observed, y_observed,
                            g2=11.4 / (1 - 0.63) / 0.96):
         return g2 * s2_map(np.transpose([x_observed, y_observed]))
@@ -123,6 +131,7 @@ class SR0Source:
     electron_gain_std = 11.4 * 0.25 / (1 - 0.63)
 
     @staticmethod
+    @make_tensor
     def photon_detection_eff(x, y, z,
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_map(np.transpose([x, y, z]))
@@ -131,10 +140,12 @@ class SR0Source:
 class SR0ERSource(SR0Source, ERSource):
 
     @staticmethod
+    @make_tensor
     def p_electron(nq):
         return safe_p(p_el_thesis(nq * 13.8e-3))
 
     @staticmethod
+    @make_tensor
     def p_electron_fluctuation(nq):
         # q3 = 1.7 keV ~= 123 quanta
         return np.clip(0.041 * (1 - np.exp(-nq/123)), 1e-4, None)
@@ -152,6 +163,7 @@ example_sp = Hist1d.from_histogram(
 
 class SR0NRSource(SR0Source, NRSource):
 
+    @make_tensor
     def energy_spectrum(self, drift_time):
         n_evts = len(drift_time)
         return (
@@ -159,5 +171,6 @@ class SR0NRSource(SR0Source, NRSource):
             example_sp.histogram[np.newaxis,:].repeat(n_evts, axis=0))
 
     @staticmethod
+    @make_tensor
     def p_electron(nq):
         return safe_p(p_electron_nr(nq))

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -2,6 +2,7 @@
 
 """
 import numpy as np
+import tensorflow as tf
 
 from multihist import Hist1d
 import straxen

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -136,7 +136,9 @@ class SR0ERSource(SR0Source, ERSource):
     @staticmethod
     def p_electron_fluctuation(nq):
         # q3 = 1.7 keV ~= 123 quanta
-        return np.clip(0.041 * (1 - np.exp(-nq/123)), 1e-4, None)
+        return tf.clip_by_value(0.041 * (1. - tf.exp(-nq / 123.)),
+                                1e-4,
+                                float('inf'))
 
 
 # Compute events/bin spectrum for a WIMP

--- a/notebooks/flamedisx_tf2.ipynb
+++ b/notebooks/flamedisx_tf2.ipynb
@@ -11,7 +11,8 @@
     "kernelspec": {
       "name": "python3",
       "display_name": "Python 3"
-    }
+    },
+    "accelerator": "GPU"
   },
   "cells": [
     {
@@ -53,10 +54,6 @@
         "\n",
         "%cd straxen\n",
         "!python setup.py develop\n",
-        "%cd ..\n",
-        "\n",
-        "%cd flamedisx\n",
-        "!python setup.py develop\n",
         "%cd .."
       ],
       "execution_count": 0,
@@ -87,10 +84,100 @@
         "colab": {}
       },
       "source": [
-        "# Install TF2 w GPU support (change runtime to GPU to test)\n",
-        "!pip install -U tensorflow-gpu==2.0.0-alpha0\n",
+        "# Install TF2 and TFP w GPU support (change runtime to GPU to test)\n",
+        "!pip install -U tensorflow-gpu==2.0.0-beta0\n",
+        "!pip install -U tensorflow_probability==0.7.0-rc0\n",
+        "\n",
         "import tensorflow as tf\n",
+        "import tensorflow_probability as tfp\n",
+        "tfd = tfp.distributions"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "D_FtZiQY5BV7",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "tf.__version__"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "KDR5AQ-S7N5_",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "tfp.__version__"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K2jAVeXf4g2y",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "tf.test.is_gpu_available()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "f7CLj5cvxZon",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "tf.executing_eagerly()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SERg0ovF_c0i",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Failed: 1d9d3840b41e3a1c319647b090862d238034a30f\n",
+        "\n",
+        "# Still worked: dc616691fcb21234a625fa6081d4ab292beb73d9\n",
+        "  "
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jPfcCkAb06QV",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Set flamedisx dev branch\n",
+        "%cd flamedisx\n",
+        "!git checkout dev_tf\n",
+        "!git pull origin dev_tf\n",
+        "#!git checkout dc616691fcb21234a625fa6081d4ab292beb73d9\n",
+        "!python setup.py develop\n",
+        "%cd .."
       ],
       "execution_count": 0,
       "outputs": []
@@ -103,7 +190,7 @@
       },
       "source": [
         "# Run Flamedisx\n",
-        "(the model_checks notebook)"
+        "(the code from the model_checks notebook)"
       ]
     },
     {
@@ -119,9 +206,22 @@
         "from tqdm import tqdm\n",
         "import matplotlib\n",
         "import matplotlib.pyplot as plt\n",
-        "%matplotlib inline\n",
+        "%matplotlib inline"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kC8ZuJZIWOar",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "from multihist import Hist1d\n",
         "\n",
+        "import flamedisx\n",
         "from flamedisx.x1t_sr0 import SR0NRSource, SR0ERSource\n",
         "\n",
         "# raise errors on any warning\n",
@@ -145,6 +245,8 @@
         "    nr=dict(source=SR0NRSource(),\n",
         "            data=pd.read_csv(data_path + 'data_AmBe_lowenergy.csv')[::8]))\n",
         "\n",
+        "# dsets['er']['source'].do_pel_fluct = False\n",
+        "\n",
         "def std_axes():\n",
         "    plt.xlabel(\"S1 [PE]\")\n",
         "    plt.ylabel(r\"S2 [PE]\")\n",
@@ -165,8 +267,7 @@
         "    plt.scatter(d['s1'], d['s2'], s=2, c=d['drift_time']/1e3, cmap=plt.cm.jet)\n",
         "    plt.colorbar(label=\"Drift time [us]\")\n",
         "    std_axes()\n",
-        "    plt.show()\n",
-        "\n"
+        "    plt.show()"
       ],
       "execution_count": 0,
       "outputs": []
@@ -189,15 +290,22 @@
         "colab": {}
       },
       "source": [
-        "for dname, q in dsets.items():\n",
-        "    d = q['data']\n",
-        "    if 'likelihood' not in d.columns:\n",
-        "        d['likelihood'] = q['source'].likelihood(d, progress=tqdm)\n",
+        "for dname, q in tqdm(dsets.items()):\n",
+        "  d = q['data']\n",
+        "  if 'likelihood' in d.columns:\n",
+        "    del d['likelihood']\n",
+        "  if 'likelihood' not in d.columns:\n",
+        "    d['likelihood'] = q['source'].likelihood(d,\n",
+        "                                             progress=tqdm,\n",
+        "                                             batch_size=1000,\n",
+        "                                             max_sigma=3,\n",
+        "                                             )\n",
         "\n",
-        "    with warnings.catch_warnings():\n",
-        "        warnings.simplefilter(\"ignore\")\n",
-        "        d['ll'] = np.log10(d['likelihood'])\n",
-        "        \n",
+        "  with warnings.catch_warnings():\n",
+        "    warnings.simplefilter(\"ignore\")\n",
+        "    d['ll'] = np.log10(d['likelihood'])\n",
+        "\n",
+        "\n",
         "    plt.scatter(d['e_vis'], \n",
         "                d['electron_produced_mle'],\n",
         "                c=d['ll'], vmin=-7,\n",
@@ -208,8 +316,7 @@
         "    plt.ylabel(\"Electrons produced (est.)\")\n",
         "    plt.xlim(0, 10)\n",
         "    plt.ylim(0, None)\n",
-        "    plt.show()\n",
-        "\n"
+        "    plt.show()"
       ],
       "execution_count": 0,
       "outputs": []
@@ -251,8 +358,7 @@
         "    plt.title(dname)\n",
         "    plt.xlim(0, None)\n",
         "    plt.ylim(0, None)\n",
-        "    plt.show()\n",
-        "\n"
+        "    plt.show()\n"
       ],
       "execution_count": 0,
       "outputs": []
@@ -510,19 +616,6 @@
         "    plt.xlim(0, None if dname == 'er' else 40)\n",
         "    plt.ylabel(\"S2 [PE]\")\n",
         "    plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "veAgGS5CknZZ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        ""
       ],
       "execution_count": 0,
       "outputs": []

--- a/notebooks/flamedisx_tf2.ipynb
+++ b/notebooks/flamedisx_tf2.ipynb
@@ -150,22 +150,6 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "SERg0ovF_c0i",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Failed: 1d9d3840b41e3a1c319647b090862d238034a30f\n",
-        "\n",
-        "# Still worked: dc616691fcb21234a625fa6081d4ab292beb73d9\n",
-        "  "
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
         "id": "jPfcCkAb06QV",
         "colab_type": "code",
         "colab": {}
@@ -175,7 +159,6 @@
         "%cd flamedisx\n",
         "!git checkout dev_tf\n",
         "!git pull origin dev_tf\n",
-        "#!git checkout dc616691fcb21234a625fa6081d4ab292beb73d9\n",
         "!python setup.py develop\n",
         "%cd .."
       ],
@@ -295,11 +278,7 @@
         "  if 'likelihood' in d.columns:\n",
         "    del d['likelihood']\n",
         "  if 'likelihood' not in d.columns:\n",
-        "    d['likelihood'] = q['source'].likelihood(d,\n",
-        "                                             progress=tqdm,\n",
-        "                                             batch_size=1000,\n",
-        "                                             max_sigma=3,\n",
-        "                                             )\n",
+        "    d['likelihood'] = q['source'].likelihood(d, batch_size=1000, max_sigma=3)\n",
         "\n",
         "  with warnings.catch_warnings():\n",
         "    warnings.simplefilter(\"ignore\")\n",
@@ -474,7 +453,7 @@
         "from tqdm import tqdm\n",
         "from multihist import Histdd\n",
         "\n",
-        "n_trials = int(1e5)\n",
+        "n_trials = int(1e3)\n",
         "n_batches = 100\n",
         "evt_i = 0\n",
         "evt_df = dsets['er']['data'].iloc[evt_i:evt_i+1]\n",
@@ -489,7 +468,7 @@
         "            np.geomspace(200, 6000, 70)))\n",
         "\n",
         "        for _ in tqdm(range(n_batches)):\n",
-        "            _d = q['source'].simulate(n_trials, data=evt_df)\n",
+        "            _d = q['source'].simulate(n_trials, data=evt_df.copy())\n",
         "            mh.add(_d['s1'], _d['s2'])\n",
         "\n",
         "        # Convert to PDF\n",
@@ -524,7 +503,7 @@
         "    if 'simd' in q:\n",
         "        d = q['simd']\n",
         "    else:\n",
-        "        d = q['source'].simulate(1000, data=evt_df)\n",
+        "        d = q['source'].simulate(1000, data=evt_df.copy())\n",
         "        # Avoid extrapolation in MC likelihood\n",
         "        d = d[(d['s1'] < 70)]\n",
         "        d = d[d['s2'] < 6000]\n",
@@ -616,6 +595,19 @@
         "    plt.xlim(0, None if dname == 'er' else 40)\n",
         "    plt.ylabel(\"S2 [PE]\")\n",
         "    plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PDRNpaAIkhqL",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        ""
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Rewrite flamedisx to use tensorflow 2.0.0-beta0 and tensorflow_probability
Replaced many numpy functions with their tensorflow counterparts
Focussing on fast likelihood computation.
Runs on colab GPU nodes via flamedisx_tf2.ipynb notebook