### PR TITLE
Fix tests and setup for CPU development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+dist: xenial
+python:
+- '3.6'
+- '3.7'
+install:
+- pip install -r requirements.txt
+script:
+- python setup.py test
+deploy:
+  provider: pypi
+  skip_existing: true
+  user: jelleaalbers
+  password:
+    secure: Xc8Yg9fT1D/GgGlucut3otsboOnJzb1rgiSVnUXrMNWDZyhXghsZXz1PAGGU/reGSDwqpJWzwcEAbOwuH7U0XPie6lAj1ZdzLHnIkAqvCqSvGMaMJSN53gzXA+HoX7LAWZFOQCJqZMWs+1W2YiiZX7FVJEearCjO7tf0VIOHbS8Fi44oYbut6nYjFjQgQOoEdWLa3Zt5tpS46nCwCVbi0jjL48r4gNqG8TmFfWtozHFwiDLcm/Gemo6Q2VU5I6wi/iFZw0tOnRLysxZOV/gKQViFRXZkwVx++fGo/D6kkUY6Gaiou5EJjk9K0Aebr9RHK8oZhHT6YZOnwP6O6DuTSjdagodAGlZjITIsfWIman3Pu5TYUDhhW2c4+drcwN3YytjUo7xUl3KpGO/V9Ucz3UTsv1nJkbJypA3CnovA0oO72ydjMEBfxjWi++uoubuLStwdVcv3me1RYkGNGNRyFo4AT0hZlF6y7KwHYhzNAkhBztVXV4OEGOxWtrwPhJzyu/EvQWjMAIVjjOJXSU/Ca4vNc8SyEtvnRwAJk8u8obhz3OHpmKKl79ziOdkBWPVZftUg2+ht64LVaef1bvPH+3QbcS9fx/ewU3TPQFoX/SPqsP/U1q53DfKB0RH9+a/vHhLjrr6fj4h7lYttCIppnOiQsYRR+L2nRA/1ok6V3tI=
+  on:
+    tags: true

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -5,10 +5,11 @@ import numpy as np
 import tensorflow as tf
 
 from multihist import Hist1d
-import straxen
 import wimprates
 
 from flamedisx import ERSource, NRSource
+from flamedisx.xenon_corrections import (
+    InterpolatingMap, get_resource, pax_file)
 
 ##
 # Electron probability
@@ -89,15 +90,11 @@ def p_electron_nr(
 ##
 
 
-s1_map = straxen.InterpolatingMap(
-        straxen.get_resource(
-            straxen.pax_file(
+s1_map = InterpolatingMap(get_resource(pax_file(
                 'XENON1T_s1_xyz_ly_kr83m_SR0_pax-642_fdc-AdCorrTPF.json')))
 
-s2_map = straxen.InterpolatingMap(
-        straxen.get_resource(
-            straxen.pax_file(
-                'XENON1T_s2_xy_ly_SR0_24Feb2017.json')))
+s2_map = InterpolatingMap(get_resource(pax_file(
+    'XENON1T_s2_xy_ly_SR0_24Feb2017.json')))
 
 
 ##

--- a/flamedisx/xenon_corrections.py
+++ b/flamedisx/xenon_corrections.py
@@ -1,0 +1,215 @@
+from base64 import b32encode
+import logging
+import gzip
+from hashlib import sha1
+import json
+import os
+import os.path as osp
+import re
+import urllib.request
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+
+class InterpolateAndExtrapolate(object):
+    """Linearly interpolate- and extrapolate using inverse-distance
+    weighted averaging between nearby points.
+    """
+
+    def __init__(self, points, values, neighbours_to_use=None):
+        """
+        :param points: array (n_points, n_dims) of coordinates
+        :param values: array (n_points) of values
+        :param neighbours_to_use: Number of neighbouring points to use for
+        averaging. Default is 2 * dimensions of points.
+        """
+        self.kdtree = cKDTree(points)
+        self.values = values
+        if neighbours_to_use is None:
+            neighbours_to_use = points.shape[1] * 2
+        self.neighbours_to_use = neighbours_to_use
+
+    def __call__(self, points):
+        distances, indices = self.kdtree.query(points, self.neighbours_to_use)
+        # If one of the coordinates is NaN, the neighbour-query fails.
+        # If we don't filter these out, it would result in an IndexError
+        # as the kdtree returns an invalid index if it can't find neighbours.
+        result = np.ones(len(points)) * float('nan')
+        valid = (distances < float('inf')).max(axis=-1)
+        result[valid] = np.average(
+            self.values[indices[valid]],
+            weights=1/np.clip(distances[valid], 1e-6, float('inf')),
+            axis=-1)
+        return result
+
+
+class InterpolatingMap(object):
+    """Correction map that computes values using inverse-weighted distance
+    interpolation.
+
+    The map must be specified as a json translating to a dictionary like this:
+        'coordinate_system' :   [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...],
+        'map' :                 [value1, value2, value3, value4, ...]
+        'another_map' :         idem
+        'name':                 'Nice file with maps',
+        'description':          'Say what the maps are, who you are, etc',
+        'timestamp':            unix epoch seconds timestamp
+
+    with the straightforward generalization to 1d and 3d.
+
+    The default map name is 'map', I'd recommend you use that.
+
+    For a 0d placeholder map, use
+        'points': [],
+        'map': 42,
+        etc
+
+    """
+    data_field_names = ['timestamp', 'description', 'coordinate_system',
+                        'name', 'irregular']
+
+    def __init__(self, data):
+        self.log = logging.getLogger('InterpolatingMap')
+
+        if isinstance(data, bytes):
+            data = gzip.decompress(data).decode()
+        self.data = json.loads(data)
+
+        self.coordinate_system = cs = self.data['coordinate_system']
+        if not len(cs):
+            self.dimensions = 0
+        else:
+            self.dimensions = len(cs[0])
+        self.interpolators = {}
+        self.map_names = sorted([k for k in self.data.keys()
+                                 if k not in self.data_field_names])
+        self.log.debug('Map name: %s' % self.data['name'])
+        self.log.debug('Map description:\n    ' +
+                       re.sub(r'\n', r'\n    ', self.data['description']))
+        self.log.debug("Map names found: %s" % self.map_names)
+
+        for map_name in self.map_names:
+            map_data = np.array(self.data[map_name])
+            if self.dimensions == 0:
+                # 0 D -- placeholder maps which take no arguments
+                # and always return a single value
+                def itp_fun(positions):
+                    return map_data * np.ones_like(positions)
+            else:
+                itp_fun = InterpolateAndExtrapolate(points=np.array(cs),
+                                                    values=np.array(map_data))
+
+            self.interpolators[map_name] = itp_fun
+
+    def __call__(self, positions, map_name='map'):
+        """Returns the value of the map at the position given by coordinates
+        :param positions: array (n_dim) or (n_points, n_dim) of positions
+        :param map_name: Name of the map to use. Default is 'map'.
+        """
+        return self.interpolators[map_name](positions)
+
+
+cache_dict = dict()
+
+
+def get_resource(x, fmt='text'):
+    """Return contents of file or URL x
+    :param binary: Resource is binary. Return bytes instead of a string.
+    """
+    is_binary = fmt != 'text'
+
+    # Try to retrieve from in-memory cache
+    if x in cache_dict:
+        return cache_dict[x]
+
+    if '://' in x:
+        # Web resource; look first in on-disk cache
+        # to prevent repeated downloads.
+        cache_fn = deterministic_hash(x)
+        cache_folders = ['./resource_cache',
+                         '/tmp/straxen_resource_cache',
+                         '/dali/lgrandi/strax/resource_cache']
+        for cache_folder in cache_folders:
+            try:
+                os.makedirs(cache_folder, exist_ok=True)
+            except (PermissionError, OSError):
+                continue
+            cf = osp.join(cache_folder, cache_fn)
+            if osp.exists(cf):
+                return get_resource(cf, fmt=fmt)
+
+        # Not found in any cache; download
+        result = urllib.request.urlopen(x).read()
+        if not is_binary:
+            result = result.decode()
+
+        # Store in as many caches as possible
+        m = 'wb' if is_binary else 'w'
+        available_cf = None
+        for cache_folder in cache_folders:
+            if not osp.exists(cache_folder):
+                continue
+            cf = osp.join(cache_folder, cache_fn)
+            try:
+                with open(cf, mode=m) as f:
+                    f.write(result)
+            except Exception:
+                pass
+            else:
+                available_cf = cf
+        if available_cf is None:
+            raise RuntimeError(
+                f"Could not load {x},"
+                "none of the on-disk caches are writeable??")
+
+        # Retrieve result from file-cache
+        # (so we only need one format-parsing logic)
+        return get_resource(available_cf, fmt=fmt)
+
+    # File resource
+    if fmt == 'npy':
+        result = np.load(x)
+    elif fmt == 'binary':
+        with open(x, mode='rb') as f:
+            result = f.read()
+    elif fmt == 'text':
+        with open(x, mode='r') as f:
+            result = f.read()
+
+    # Store in in-memory cache
+    cache_dict[x] = result
+
+    return result
+
+
+def hashablize(obj):
+    """Convert a container hierarchy into one that can be hashed.
+    See http://stackoverflow.com/questions/985294
+    """
+    try:
+        hash(obj)
+    except TypeError:
+        if isinstance(obj, dict):
+            return tuple((k, hashablize(v)) for (k, v) in sorted(obj.items()))
+        elif isinstance(obj, np.ndarray):
+            return tuple(obj.tolist())
+        elif hasattr(obj, '__iter__'):
+            return tuple(hashablize(o) for o in obj)
+        else:
+            raise TypeError("Can't hashablize object of type %r" % type(obj))
+    else:
+        return obj
+
+
+def deterministic_hash(thing, length=10):
+    """Return a base32 lowercase string of length determined from hashing
+    a container hierarchy
+    """
+    digest = sha1(json.dumps(hashablize(thing)).encode('ascii')).digest()
+    return b32encode(digest)[:length].decode('ascii').lower()
+
+
+def pax_file(x):
+    """Return URL to file hosted in the pax repository master branch"""
+    return 'https://raw.githubusercontent.com/XENON1T/pax/master/pax/data/' + x

--- a/notebooks/flamedisx_tf2.ipynb
+++ b/notebooks/flamedisx_tf2.ipynb
@@ -6,8 +6,7 @@
       "name": "flamedisx_tf2.ipynb",
       "version": "0.3.2",
       "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -39,21 +38,15 @@
       "source": [
         "from __future__ import absolute_import, division, print_function, unicode_literals\n",
         "\n",
-        "# !pip install tensorflow-gpu==2.0.0-alpha0  # Install last, maybe some issue w straxen\n",
-        "!pip install blosc\n",
+        "\n",
         "!pip install wimprates\n",
-        "# !pip install multihist  # wait for new multihist release, clone in meantime\n",
+        "#!pip install multihist  # wait for new multihist release, clone in meantime\n",
         "!git clone https://github.com/JelleAalbers/multihist.git\n",
         "\n",
-        "!git clone https://github.com/XENONnT/straxen.git\n",
         "!git clone https://github.com/JelleAalbers/flamedisx.git\n",
         "\n",
         "# Install multihist (remove once new multihist release becomes available)\n",
         "%cd multihist\n",
-        "!python setup.py develop\n",
-        "%cd ..\n",
-        "\n",
-        "%cd straxen\n",
         "!python setup.py develop\n",
         "%cd .."
       ],
@@ -86,7 +79,7 @@
       },
       "source": [
         "# Install TF2 and TFP w GPU support (change runtime to GPU to test)\n",
-        "!pip install -U tensorflow-gpu==2.0.0-beta0\n",
+        "!pip install -U tensorflow-gpu==2.0.0-beta1\n",
         "!pip install -U tensorflow_probability==0.7.0-rc0\n",
         "\n",
         "import tensorflow as tf\n",
@@ -156,8 +149,10 @@
         "colab": {}
       },
       "source": [
-        "# Set flamedisx dev branch\n",
+        "# Install flamedisx\n",
         "%cd flamedisx\n",
+        "#!git checkout cpu_dev\n",
+        "#!git pull origin cpu_dev\n",
         "!python setup.py develop\n",
         "%cd .."
       ],
@@ -277,7 +272,7 @@
         "  if 'likelihood' in d.columns:\n",
         "    del d['likelihood']\n",
         "  if 'likelihood' not in d.columns:\n",
-        "    d['likelihood'] = q['source'].likelihood(d, batch_size=1000, max_sigma=3)\n",
+        "    d['likelihood'] = q['source'].likelihood(d, batch_size=None, max_sigma=3)\n",
         "\n",
         "  with warnings.catch_warnings():\n",
         "    warnings.simplefilter(\"ignore\")\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ numpy
 scipy
 pandas
 multihist
+wimprates
+tensorflow=2.0.0-beta1
+tensorflow_probability==0.7.0-rc0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy
 pandas
 multihist
 wimprates
-tensorflow=2.0.0-beta1
+tensorflow==2.0.0-beta1
 tensorflow_probability==0.7.0-rc0


### PR DESCRIPTION
This:
  * "Ports the flamedisx tests to tensorflow"... which in practice means adding '.numpy()' after the flamedisx calls, so we can then use numpy for the tests.
  * Removes the depedency on straxen by duplicating the necessary pieces of code. When straxen moves away from tensorflow 1, we can change this (but that could be a while).
  * Fix a few bugs that made the tests fail, but did not cause a visible problem in the GPU tests in colab:
    * lookup_axis1 used out-of-bounds indices
    * Added a few numpy_out and .values to prevent pandas Series from messing up simulate_nq. On master this code currently causes a core dump.
    * The bound of {quantum}_produced was calculated so weirdly that it could come out lower than the MLE. This was likely present already before the tensorflow port, but it manifested only now (perhaps some rounding has changed). The calculation is still weird, but at least now it passes this minimal test.
  * Remove a few unused lines (likely present before the port)
  * Add a very crude batch system back in: just a for loop over set_data and likelihood. Without this I can't compute the likelihood for a reasonable number of events on my poor 8GB RAM laptop.
  * Add TravisCI

@pelssers / @CristianAntochi could i ask one of you to check that flamedisx still works fine on colab? The setup might be easier now that the requirements.txt is updated, although you'd still have to install tensorflow-gpu manually.