### PR TITLE
Port remaining functions to tf, rearrange things

### DIFF
--- a/flamedisx/__init__.py
+++ b/flamedisx/__init__.py
@@ -1,4 +1,6 @@
 __version__ = '0.0.1'
 
-from . import core
-from .core import ERSource, NRSource
+from .utils import *
+from .xenon_corrections import *
+from .core import *
+from .x1t_sr0 import *

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -1,0 +1,84 @@
+import numpy as np
+import tensorflow as tf
+
+o = tf.newaxis
+
+
+def exporter():
+    """Export utility modified from https://stackoverflow.com/a/41895194
+    Returns export decorator, __all__ list
+    """
+    all_ = []
+    def decorator(obj):
+        all_.append(obj.__name__)
+        return obj
+    return decorator, all_
+
+
+export, __all__ = exporter()
+__all__.append('exporter')
+
+
+@export
+def lookup_axis1(x, indices, fill_value=0):
+    """Return values of x at indices along axis 1,
+       returning fill_value for out-of-range indices.
+    """
+    # Save shape of x and flatten
+    a, b = x.shape
+    x = tf.reshape(x, [-1])
+
+    legal_index = indices < b
+
+    # Convert indices to legal indices in flat array
+    indices = tf.dtypes.cast(indices, dtype=tf.int32)
+    indices = tf.clip_by_value(indices, 0, b - 1)
+    indices = indices + b * tf.range(a)[:, o, o]
+
+    # Do indexing
+    result = tf.reshape(tf.gather(x,
+                                  tf.reshape(indices, shape=(-1,))),
+                        shape=indices.shape)
+
+    # Replace illegal indices with fill_value, cast to float explicitly
+    return tf.cast(tf.where(legal_index,
+                            result,
+                            tf.zeros_like(result) + fill_value),
+                   dtype=tf.float32)
+
+
+@export
+def tf_to_np(x):
+    """Convert (list/tuple of) tensors x to numpy"""
+    if isinstance(x, (list, tuple)):
+        return tuple([tf_to_np(y) for y in x])
+    if isinstance(x, np.ndarray):
+        return x
+    return x.numpy()
+
+
+@export
+def np_to_tf(x):
+    """Convert (list/tuple of) arrays x to tensorflow"""
+    if isinstance(x, (list, tuple)):
+        return tuple([np_to_tf(y) for y in x])
+    if isinstance(x, tf.Tensor):
+        return x
+    return tf.convert_to_tensor(x, dtype=tf.float32)
+
+
+@export
+def tf_log10(x):
+    return tf.math.log(x) / tf.math.log(tf.constant(10, dtype=x.dtype))
+
+
+@export
+def safe_p(ps):
+    """Clip probabilities to be in [1e-5, 1 - 1e-5]
+    NaNs are replaced by 1e-5.
+    """
+    ps = tf.where(tf.math.is_nan(ps),
+                  tf.zeros_like(ps),
+                  ps)
+    ps = tf.clip_by_value(ps, 1e-5, 1 - 1e-5)
+    return ps

--- a/flamedisx/xenon_corrections.py
+++ b/flamedisx/xenon_corrections.py
@@ -11,7 +11,11 @@ import urllib.request
 import numpy as np
 from scipy.spatial import cKDTree
 
+import flamedisx as fd
+export, __all__ = fd.exporter()
 
+
+@export
 class InterpolateAndExtrapolate(object):
     """Linearly interpolate- and extrapolate using inverse-distance
     weighted averaging between nearby points.
@@ -44,6 +48,7 @@ class InterpolateAndExtrapolate(object):
         return result
 
 
+@export
 class InterpolatingMap(object):
     """Correction map that computes values using inverse-weighted distance
     interpolation.
@@ -113,6 +118,7 @@ class InterpolatingMap(object):
 cache_dict = dict()
 
 
+@export
 def get_resource(x, fmt='text'):
     """Return contents of file or URL x
     :param binary: Resource is binary. Return bytes instead of a string.
@@ -183,6 +189,7 @@ def get_resource(x, fmt='text'):
     return result
 
 
+@export
 def hashablize(obj):
     """Convert a container hierarchy into one that can be hashed.
     See http://stackoverflow.com/questions/985294
@@ -202,6 +209,7 @@ def hashablize(obj):
         return obj
 
 
+@export
 def deterministic_hash(thing, length=10):
     """Return a base32 lowercase string of length determined from hashing
     a container hierarchy
@@ -210,6 +218,7 @@ def deterministic_hash(thing, length=10):
     return b32encode(digest)[:length].decode('ascii').lower()
 
 
+@export
 def pax_file(x):
     """Return URL to file hosted in the pax repository master branch"""
     return 'https://raw.githubusercontent.com/XENON1T/pax/master/pax/data/' + x

--- a/notebooks/flamedisx_tf2.ipynb
+++ b/notebooks/flamedisx_tf2.ipynb
@@ -151,8 +151,8 @@
       "source": [
         "# Install flamedisx\n",
         "%cd flamedisx\n",
-        "#!git checkout cpu_dev\n",
-        "#!git pull origin cpu_dev\n",
+        "#!git checkout tf_f\n",
+        "#!git pull origin tf_f\n",
         "!python setup.py develop\n",
         "%cd .."
       ],
@@ -272,7 +272,9 @@
         "  if 'likelihood' in d.columns:\n",
         "    del d['likelihood']\n",
         "  if 'likelihood' not in d.columns:\n",
-        "    d['likelihood'] = q['source'].likelihood(d, batch_size=None, max_sigma=3)\n",
+        "    q['source'].set_data(d, max_sigma=3)\n",
+        "    d['likelihood'] = q['source'].likelihood()\n",
+        "    #d['likelihood'] = q['source'].batched_likelihood(batch_size=50)\n",
         "\n",
         "  with warnings.catch_warnings():\n",
         "    warnings.simplefilter(\"ignore\")\n",
@@ -290,6 +292,49 @@
         "    plt.xlim(0, 10)\n",
         "    plt.ylim(0, None)\n",
         "    plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "I2zEOvXOaWGw",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%timeit\n",
+        "q['source']._likelihood(elife=tf.constant(500e3))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6XKViyNgcqg1",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Running the autograph likelihood\n",
+        "%%timeit\n",
+        "q['source'].likelihood(elife=tf.constant(500e3))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zrNVIi2NctqK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%timeit\n",
+        "q['source'].likelihood(elife=tf.constant(500e3))"
       ],
       "execution_count": 0,
       "outputs": []

--- a/notebooks/models_check.ipynb
+++ b/notebooks/models_check.ipynb
@@ -71,8 +71,9 @@
    "source": [
     "for dname, q in dsets.items():\n",
     "    d = q['data']\n",
+    "    q['source'].set_data(d)\n",
     "    if 'likelihood' not in d.columns:\n",
-    "        d['likelihood'] = q['source'].likelihood(d, progress=tqdm)\n",
+    "        d['likelihood'] = q['source'].batched_likelihood()\n",
     "\n",
     "    with warnings.catch_warnings():\n",
     "        warnings.simplefilter(\"ignore\")\n",
@@ -108,7 +109,6 @@
     "    s = q['source']\n",
     "    d = s.simulate(len(q['data']))\n",
     "    \n",
-    "    s.annotate_data(d)\n",
     "    d = d[d['e_vis'] < 10]\n",
     "    q['data_sim'] = d\n",
     "    \n",
@@ -278,10 +278,8 @@
     "\n",
     "        # Note the higher max_sigma here to ensure good results\n",
     "        # TODO: fix bound calcs!\n",
-    "        d['likelihood'] = q['source'].likelihood(\n",
-    "            d, \n",
-    "            max_sigma=3 if dname == 'er' else 4, \n",
-    "            progress=tqdm)\n",
+    "        q['source'].set_data(d, max_sigma=3 if dname == 'er' else 4)\n",
+    "        d['likelihood'] = q['source'].batched_likelihood()\n",
     "        d['likelihood_2'] = q['mh'].lookup(d['s1'], d['s2'])\n",
     "    \n",
     "    with warnings.catch_warnings():\n",
@@ -355,13 +353,6 @@
     "    plt.ylabel(\"S2 [PE]\")\n",
     "    plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -380,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ scipy
 pandas
 multihist
 wimprates
+tqdm
 tensorflow==2.0.0-beta1
 tensorflow_probability==0.7.0-rc0


### PR DESCRIPTION
This adds the following:
  * Port the remaining functions in ``x1t_sr0.py``, and the core function ``_dimsize``, to tensorflow. All functions called in ``likelihood`` should now be pure tensorflow.
    * The S1 and S2 relative light yields are now evaluated once during set_data, rather than every time during a likelihood call. This is done by the new function ``add_extra_columns``.
  * ``likelihood`` is now a ``@tf.function`` function that returns tensors. It does not use batching and only takes the likelihood parameters as arguments. It seems to work as expected (first call is slow, next ones faster), though I've only been able to test this with a few events on my laptop.
  * Move the crude batching to a new function ``batched_likelihood``, which returns numpy arrays. This evaluates likelihoods for all events by splitting the data into batches and repeatedly calling ``set_data``. It does not use the `@tf.function`'ed likelihood, since it seems this does not refresh its inputs as expected during the batching.
  * Move the annotation of the data (bound estimation etc.) to ``annotate_data``. Conversely, ``set_data`` calls ``annotate_data``, unless the option ``annotated=True`` is passed.
  * Move some utility functions into ``utils.py``, and use the ``@export`` mechanism throughout flamedisx.
  * Clean up gimme and add tests described in (#4)

@pelssers / @CristianAntochi  I would again be grateful if you can see how this affects things in colab.