### PR TITLE
Optimize lookup_axis1

### DIFF
--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -34,20 +34,22 @@ def lookup_axis1(x, indices, fill_value=0):
        returning fill_value for out-of-range indices.
     """
     # Save shape of x and flatten
+    ind_shape = indices.shape
     a, b = x.shape
     x = tf.reshape(x, [-1])
 
     legal_index = indices < b
 
     # Convert indices to legal indices in flat array
+    indices = tf.clip_by_value(indices, 0., b - 1.)
+    indices = indices + b * tf.range(a, dtype=float_type())[:, o, o]
+    indices = tf.reshape(indices, shape=(-1,))
     indices = tf.dtypes.cast(indices, dtype=tf.int32)
-    indices = tf.clip_by_value(indices, 0, b - 1)
-    indices = indices + b * tf.range(a)[:, o, o]
 
     # Do indexing
     result = tf.reshape(tf.gather(x,
-                                  tf.reshape(indices, shape=(-1,))),
-                        shape=indices.shape)
+                                  indices),
+                        shape=ind_shape)
 
     # Replace illegal indices with fill_value, cast to float explicitly
     return tf.cast(tf.where(legal_index,


### PR DESCRIPTION
This optimizes the `lookup_axis1` function and speeds up `differential_rate` by almost a factor 2 for NR data.

When profiling the `differential_rate` function we see that in `lookup_axis1` memory is copied back to the host while the GPU remains idle. The `tf.clip_by_value`, addition and `tf.reshape` is done on the CPU instead of the GPU, this is because the tensor is cast to an integer type (since we later give to `tf.gather`).

By putting the cast after the clip and reshape operations everything is executed on the GPU instead.

Running `differential_rate` on Colab with 1/8 of the NR data and `batch_size=40` the time decreases from 265ms to 140ms.

Also on ER data the differential rate is calculated slightly faster (1.27s from 1.31s) but this is mainly limited by the calculation of the Dirichlet Multinomial.