### PR TITLE
Switch to Tensorflow 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ pandas
 multihist
 wimprates
 tqdm
-gast==0.2.2
 tensorflow==2.0.0
 tensorflow_probability==0.8.0-rc0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ multihist
 wimprates
 tqdm
 gast==0.2.2
-tensorflow==2.0.0-rc0
+tensorflow==2.0.0
 tensorflow_probability==0.8.0-rc0


### PR DESCRIPTION
Tensorflow 2.0.0 is released. Changing the requirements to reflect this. This also removes the need for a fixed version of `gast==0.2.2` in the requirements.