### PR TITLE
Add spatial response to sources

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -88,7 +88,7 @@ class LXeSource(fd.Source):
             assert np.allclose(h.mean() * h.size, self.spatial_hist.n), \
                 "spatial_hist needs to be normalized to histogram mean"
             # Check histogram dimensions
-            axes = self.spatial_h.axis_names
+            axes = self.spatial_hist.axis_names
             assert axes == ['r', 'theta', 'z'] or axes == ['x', 'y', 'z'], \
                 "axis_names of spatial_hist must be either ['r', 'theta', 'z'] or ['x', 'y', 'z']"
             self.spatial_hist_dims = axes

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -69,8 +69,8 @@ class LXeSource(fd.Source):
     t_start = pd.to_datetime('2016-09-13T12:00:00')
     t_stop = pd.to_datetime('2017-09-13T12:00:00')
 
-    # spatial response histogram
-    # Multihist object used to lookup multipliers for the spatial response
+    # Spatial response histogram
+    # Multihist Histdd object to lookup multipliers for the spatial response
     # The histogram must have 'axis_names' set to either
     # ['r', 'theta', 'z'] or ['x', 'y', 'z']
     # The histogram must be normalized to the histogram mean
@@ -90,7 +90,8 @@ class LXeSource(fd.Source):
             # Check histogram dimensions
             axes = self.spatial_hist.axis_names
             assert axes == ['r', 'theta', 'z'] or axes == ['x', 'y', 'z'], \
-                "axis_names of spatial_hist must be either ['r', 'theta', 'z'] or ['x', 'y', 'z']"
+                ("axis_names of spatial_hist must be either "
+                 "or ['r', 'theta', 'z'] or ['x', 'y', 'z']")
             self.spatial_hist_dims = axes
         # Init rest of Source
         super().__init__(*args, **kwargs)
@@ -99,7 +100,7 @@ class LXeSource(fd.Source):
         super()._populate_tensor_cache()
         if self.spatial_hist is not None:
             # Setup tensor of histogram for lookup
-            positions = self.data[list(self.spatial_hist_dims)].values.T
+            positions = self.data[self.spatial_hist_dims].values.T
             v = self.spatial_hist.lookup(*positions)
 
             spatial_tensor = tf.convert_to_tensor(v, dtype=fd.float_type())

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ multihist
 wimprates
 tqdm
 tensorflow==2.0.0
-tensorflow_probability==0.8.0-rc0
+tensorflow_probability==0.8.0


### PR DESCRIPTION
_This PR needs to merged **after** PR #24. I'll probably rebase this branch to get the commit history cleaned before merging._

This adds the option for `LXeSource` sources to have a 3D spatial response (i.e. the rate of events depends also on the interaction position of the event in the TPC).
This can be used to model for example ER events from materials background which are located primarily at the edges of the detector. Using the observed position of events from sources with different spatial responses improves discrimination power. In combination with PR #24 this allows flamedisx to use full 6D (S1, S2, x, y, z, t) sources and likelihood.

Caveats:
 - The spatial response histogram simply multiplies the differential rate at a given position. This means that correlations between the energy spectrum shape and event position are not taken into account. This is fine for most cases which are ER sources with flat energy spectra. It might not be correct for neutrons.
 - The `WIMPSource` source does not use the spatial response, only spatially uniform WIMP sources are supported.
   - This is fixed in #28 (solving issue #23) which makes `random_truth` more general and also uses `spatial_hist` in `WIMPSource`. However we might want to warn users if they make a non spatially uniform WIMP source..

Technical details and requirements on the spatial response histogram:
 - The histogram needs to be a multihist `Histdd` object with `axis_names` being either `['r', 'theta', 'z']` or `['x', 'y', 'z']` for cylindrical and Cartesian coordinate systems respectively.
- When using cylindrical coordinates the bin volumes are not uniform, the histogram should be scaled using the bin volumes accordingly before using it in a source. Since users are free to use non-uniform binning (also for Cartesian coordinates) they are responsible for correctly scaling the bins.
- The histogram needs to be normalized to have a mean value of 1.

All three above requirements are asserted in the `LXESource` init.

Tensorflow probability 0.8.0 was released, `requirements.txt` is updated.
