### PR TITLE
Fixing observables in simulate

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -179,19 +179,7 @@ class LXeSource(fd.Source):
     # Simulation
     ##
 
-    @staticmethod
-    def cart_to_pol(x, y):
-        return (x**2 + y**2)**0.5, np.arctan2(y, x)
-
-    @staticmethod
-    def pol_to_cart(r, theta):
-        return r * np.cos(theta), r * np.sin(theta)
-
     def random_truth(self, energies, fix_truth=None, **params):
-        # Note that random_truth is redefined in WIMPSource where
-        # spatial response will always be uniform (which is ok)
-        # TODO: make this more explicit to users?
-
         if isinstance(energies, (int, float)):
             n_events = energies
             # Draw energies from the spectrum
@@ -204,50 +192,91 @@ class LXeSource(fd.Source):
             raise ValueError(
                 f"Energies must be int or array, not {type(energies)}")
 
-        data = dict()
-        if fix_truth is None:
-            # Add fake s1, s2 necessary for set_data to succeed
-            # TODO: check if we still need this...
-            data['s1'] = 1
-            data['s2'] = 100
-
-            if self.spatial_hist is None:
-                # Draw uniform position
-                data['r'] = (np.random.rand(n_events) * self.tpc_radius**2)**0.5
-                data['theta'] = np.random.uniform(0, 2*np.pi, size=n_events)
-                data['z'] = - np.random.rand(n_events) * self.tpc_length
-                data['x'], data['y'] = self.pol_to_cart(data['r'], data['theta'])
-            elif self.spatial_hist_dims == ['r', 'theta', 'z']:
-                # Spatial response in cylindrical coords
-                positions = self.spatial_hist.get_random(size=n_events)
-                for idx, col in enumerate(self.spatial_hist_dims):
-                    data[col] = positions[:, idx]
-                data['x'], data['y'] = self.pol_to_cart(data['r'], data['theta'])
-            else:
-                # Spatial response in cartesian coords
-                positions = self.spatial_hist.get_random(size=n_events)
-                for idx, col in enumerate(self.spatial_hist_dims):
-                    data[col] = positions[:, idx]
-                data['r'], data['theta'] = self.cart_to_pol(data['x'], data['y'])
-
-            data['drift_time'] = - data['z']/ self.drift_velocity
-
-            # Draw uniform time
-            data['event_time'] = np.random.uniform(
-                pd.Timestamp(self.t_start).value,
-                pd.Timestamp(self.t_stop).value,
-                size=n_events).astype('float32')
-        else:
-            if isinstance(fix_truth, pd.DataFrame):
-                # Assume fix_truth is a one-line dataframe
-                fix_truth = fix_truth.iloc[0]
-
-            for c in ['x', 'y', 'z', 'r', 'event_time', 'drift_time']:
-                data[c] = np.ones(n_events, dtype=np.float32) * fix_truth[c]
-            data['theta'] = np.arctan2(data['y'], data['x'])
-
+        data = self.random_truth_observables(n_events)
         data['energy'] = energies
+
+        if fix_truth is not None:
+            # Override any keys with fixed values defined in fix_truth
+            fix_truth = self.validate_fix_truth(fix_truth)
+            for k, v in fix_truth.items():
+                data[k] = v
+
         return pd.DataFrame(data)
+
+    def validate_fix_truth(self, d):
+        """Clean fix_truth, ensure all needed variables are present
+           Compute derived variables.
+        """
+        if isinstance(d, pd.DataFrame):
+            # TODO: Should we still support this case? User has no control
+            # over which cols to set, why not only use dicts here?
+
+            # When passing in an event as DataFrame we select and set
+            # only these columns:
+            cols = ['x', 'y', 'z', 'r', 'theta', 'event_time', 'drift_time']
+            # Assume fix_truth is a one-line dataframe with at least
+            # cols columns
+            return d[cols].iloc[0].to_dict()
+        else:
+            assert isinstance(d, dict), \
+                "fix_truth needs to be a DataFrame or dict"
+
+        if all(v in d for v in ['x', 'y', 'z']):
+            # fixed position specified in cartesian coords
+            # Add cylindrical and drift_time
+            d['r'], d['theta'] = fd.cart_to_pol(d['x'], d['y'])
+            d['drift_time'] = - d['z']/ self.drift_velocity
+        elif all(v in d for v in ['r', 'theta', 'z']):
+            # fixed position specified in cylindrical coords
+            # Add cartesian and drift_time
+            d['x'], d['y'] = fd.pol_to_cart(d['r'], d['theta'])
+            d['drift_time'] = - d['z']/ self.drift_velocity
+        elif 'event_time' not in d:
+            # Neither cartesian nor polar coords given and no time
+            raise ValueError(f"Dict should contain at least ['x', 'y', 'z'] "
+                             "and/or ['r', 'theta', 'z'] and/or 'event_time', "
+                             "instead it contains: {d.keys()}")
+        return d
+
+    def random_truth_observables(self, n_events):
+        """Return dictionary with x, y, z, r, theta, drift_time
+        and event_time randomly drawn.
+        S1 and S2 placeholder values are added for set_data.
+        Takes into account spatial response of source.
+        """
+        data = dict()
+        # Add fake s1, s2 necessary for set_data to succeed
+        # TODO: check if we still need this...
+        data['s1'] = 1
+        data['s2'] = 100
+
+        if self.spatial_hist is None:
+            # Draw uniform position
+            data['r'] = (np.random.rand(n_events) * self.tpc_radius**2)**0.5
+            data['theta'] = np.random.uniform(0, 2*np.pi, size=n_events)
+            data['z'] = - np.random.rand(n_events) * self.tpc_length
+            data['x'], data['y'] = fd.pol_to_cart(data['r'], data['theta'])
+        elif self.spatial_hist_dims == ['r', 'theta', 'z']:
+            # Spatial response in cylindrical coords
+            positions = self.spatial_hist.get_random(size=n_events)
+            for idx, col in enumerate(self.spatial_hist_dims):
+                data[col] = positions[:, idx]
+            data['x'], data['y'] = fd.pol_to_cart(data['r'], data['theta'])
+        else:
+            # Spatial response in cartesian coords
+            positions = self.spatial_hist.get_random(size=n_events)
+            for idx, col in enumerate(self.spatial_hist_dims):
+                data[col] = positions[:, idx]
+            data['r'], data['theta'] = fd.cart_to_pol(data['x'], data['y'])
+
+        data['drift_time'] = - data['z']/ self.drift_velocity
+
+        # Draw uniform time
+        data['event_time'] = np.random.uniform(
+            pd.Timestamp(self.t_start).value,
+            pd.Timestamp(self.t_stop).value,
+            size=n_events).astype('float32')
+        return data
 
     ##
     # Emission model implementation
@@ -871,44 +900,36 @@ class WIMPSource(NRSource):
             n_events = energies
             # Draw energies from the spectrum
             events = self.energy_hist.get_random(n_events)
+            j2000_times = events[:, 0]
             energies = events[:, 1]
         elif isinstance(energies, (np.ndarray, pd.Series)):
             n_events = len(energies)
+            # For each energy, draw a random time
+            # this does take into account the energy/time correlation
+            # but might be very slow
+            eh = self.energy_hist
+            j2000_times = np.array([eh.slicesum(e, axis=1).get_random(size=1)
+                                    for e in energies])
 
             # When given energies, we still need event_times
-            events = self.energy_hist.get_random(n_events)
+            # But doing it like this does not include the correlation
+            #events = self.energy_hist.get_random(n_events)
+            #j2000_times = events[:, 0]
         else:
             raise ValueError(
                 f"Energies must be int or array, not {type(energies)}")
 
-        j2000_times = events[:, 0]
-        event_times = self.to_event_time(events[:, 0])
+        event_times = self.to_event_time(j2000_times)
 
-        data = dict()
-        if fix_truth is None:
-            # Add fake s1, s2 necessary for set_data to succeed
-            # TODO: check if we still need this...
-            data['s1'] = 1
-            data['s2'] = 100
-
-            # Draw uniform position
-            data['r'] = (np.random.rand(n_events) * self.tpc_radius**2)**0.5
-            data['theta'] = np.random.uniform(0, 2*np.pi, size=n_events)
-            data['x'] = data['r'] * np.cos(data['theta'])
-            data['y'] = data['r'] * np.sin(data['theta'])
-            data['z'] = - np.random.rand(n_events) * self.tpc_length
-            data['drift_time'] = - data['z']/ self.drift_velocity
-        else:
-            if isinstance(fix_truth, pd.DataFrame):
-                # Assume fix_truth is a one-line dataframe
-                fix_truth = fix_truth.iloc[0]
-
-            for c in ['x', 'y', 'z', 'drift_time']:
-                data[c] = np.ones(n_events, dtype=np.float32) * fix_truth[c]
-            data['theta'] = np.arctan2(data['y'], data['x'])
-            data['r'] = (data['x']**2 + data['y']**2)**0.5
-
+        data = self.random_truth_observables(n_events)
         data['energy'] = energies
         data['event_time'] = event_times
         data['t'] = j2000_times
+
+        if fix_truth is not None:
+            # Override any keys with fixed values defined in fix_truth
+            fix_truth = self.validate_fix_truth(fix_truth)
+            for k, v in fix_truth.items():
+                data[k] = v
+
         return pd.DataFrame(data)

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -231,11 +231,11 @@ class LXeSource(fd.Source):
             # Add cartesian and drift_time
             d['x'], d['y'] = fd.pol_to_cart(d['r'], d['theta'])
             d['drift_time'] = - d['z']/ self.drift_velocity
-        elif 'event_time' not in d:
-            # Neither cartesian nor polar coords given and no time
+        elif not any(v in d for v in ['event_time', 'energy']):
+            # Neither cartesian nor polar coords given and no time or energy
             raise ValueError(f"Dict should contain at least ['x', 'y', 'z'] "
-                             "and/or ['r', 'theta', 'z'] and/or 'event_time', "
-                             "instead it contains: {d.keys()}")
+                             "and/or ['r', 'theta', 'z'] and/or 'event_time' "
+                             "and/or 'energy', but it contains: {d.keys()}")
         return d
 
     def random_truth_observables(self, n_events):

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -84,6 +84,13 @@ def np_to_tf(x):
         return x
     return tf.convert_to_tensor(x, dtype=float_type())
 
+@export
+def cart_to_pol(x, y):
+    return (x**2 + y**2)**0.5, np.arctan2(y, x)
+
+@export
+def pol_to_cart(r, theta):
+    return r * np.cos(theta), r * np.sin(theta)
 
 @export
 def tf_log10(x):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -101,22 +101,22 @@ def test_simulate(xes: fd.ERSource):
     # Test simulate with list of energies
     simd = xes.simulate(energies=es)
 
-    np.testing.array_equal(simd['energy'].values, es)
+    np.testing.assert_array_equal(simd['energy'].values, es)
 
     # Test simulate with fix_truth DataFrame
     fix_truth_df = simd.iloc[:1].copy()
     simd = xes.simulate(energies=es, fix_truth=fix_truth_df)
 
-    np.testing.array_equal(simd['x'].values,
-                           fix_truth_df['x'].values[0])
+    np.testing.assert_array_equal(simd['x'].values,
+                                  fix_truth_df['x'].values[0])
 
     # Test simulate with fix_truth dict
     e_test = 50.
     fix_truth = dict(energy=e_test)
     simd = xes.simulate(energies=es, fix_truth=fix_truth)
 
-    np.testing.array_equal(simd['energy'].values,
-                           e_test + np.zeros(n_ev))
+    np.testing.assert_array_equal(simd['energy'].values,
+                                  e_test + np.zeros(n_ev))
 
 
 def test_bounds(xes: fd.ERSource):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -90,8 +90,33 @@ def test_gimme(xes: fd.ERSource):
 
 
 def test_simulate(xes: fd.ERSource):
-    """Test the simulator doesn't crash"""
-    xes.simulate(energies=np.linspace(0., 100., int(1e3)))
+    """Test the simulator with and without fix_truth"""
+    n_ev = int(1e3)
+    es = np.linspace(0., 100., n_ev)
+
+    # Test simulate with number of events
+    simd = xes.simulate(n_ev)
+    assert len(simd) == n_ev
+
+    # Test simulate with list of energies
+    simd = xes.simulate(energies=es)
+
+    np.testing.array_equal(simd['energy'].values, es)
+
+    # Test simulate with fix_truth DataFrame
+    fix_truth_df = simd.iloc[:1].copy()
+    simd = xes.simulate(energies=es, fix_truth=fix_truth_df)
+
+    np.testing.array_equal(simd['x'].values,
+                           fix_truth_df['x'].values[0])
+
+    # Test simulate with fix_truth dict
+    e_test = 50.
+    fix_truth = dict(energy=e_test)
+    simd = xes.simulate(energies=es, fix_truth=fix_truth)
+
+    np.testing.array_equal(simd['energy'].values,
+                           e_test + np.zeros(n_ev))
 
 
 def test_bounds(xes: fd.ERSource):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -112,7 +112,7 @@ def test_simulate(xes: fd.ERSource):
     assert simd['x'].values[0] == fix_truth_df['x'].values[0]
 
     # Test simulate with fix_truth dict
-    e_test = 50.
+    e_test = 5.
     fix_truth = dict(energy=e_test)
     simd = xes.simulate(n_ev, fix_truth=fix_truth)
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -117,6 +117,7 @@ def test_simulate(xes: fd.ERSource):
     simd = xes.simulate(n_ev, fix_truth=fix_truth)
 
     # Check if all energies are the same fixed value
+    assert 'energy' in simd
     assert len(set(simd['energy'].values)) == 1
     assert simd['energy'].values[0] == e_test
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -100,23 +100,25 @@ def test_simulate(xes: fd.ERSource):
 
     # Test simulate with list of energies
     simd = xes.simulate(energies=es)
-
-    np.testing.assert_array_equal(simd['energy'].values, es)
+    # We can't test if simd['energy'] is equal to input
+    # since events are lost due selection/detection efficiencies
 
     # Test simulate with fix_truth DataFrame
     fix_truth_df = simd.iloc[:1].copy()
-    simd = xes.simulate(energies=es, fix_truth=fix_truth_df)
+    simd = xes.simulate(n_ev, fix_truth=fix_truth_df)
 
-    np.testing.assert_array_equal(simd['x'].values,
-                                  fix_truth_df['x'].values[0])
+    # Check if all 'x' values are the same
+    assert len(set(simd['x'].values)) == 1
+    assert simd['x'].values[0] == fix_truth_df['x'].values[0]
 
     # Test simulate with fix_truth dict
     e_test = 50.
     fix_truth = dict(energy=e_test)
-    simd = xes.simulate(energies=es, fix_truth=fix_truth)
+    simd = xes.simulate(n_ev, fix_truth=fix_truth)
 
-    np.testing.assert_array_equal(simd['energy'].values,
-                                  e_test + np.zeros(n_ev))
+    # Check if all energies are the same fixed value
+    assert len(set(simd['energy'].values)) == 1
+    assert simd['energy'].values[0] == e_test
 
 
 def test_bounds(xes: fd.ERSource):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -96,7 +96,7 @@ def test_simulate(xes: fd.ERSource):
 
     # Test simulate with number of events
     simd = xes.simulate(n_ev)
-    assert len(simd) == n_ev
+    assert len(simd) <= n_ev
 
     # Test simulate with list of energies
     simd = xes.simulate(energies=es)


### PR DESCRIPTION
_This builds on #24 and #27 which need to be merged first (after which this branch might need to be rebased on master)_

This rewrites `random_truth` of `LXeSource` to solve issue #23.

When simulating events, random true values are drawn using `random_truth`. It was possible to fix the position of events by passing an event (in the form of a one-row pandas DataFrame) with `fix_truth`. This PR makes `fix_truth` also accept a dictionary whose keys can be any event observable and whose values are used for the simulated events instead of random values. This allows us to fix either the position, time or energy (or a combination thereof) when simulating events.
As a side effect of this more general implementation the `WIMPSource` now also works with an optional spatial response histogram.

Requirements on `fix_truth`:
 - a one-row pandas DataFrame that has at least the keys `['x', 'y', 'z', 'r', 'theta', 'event_time', 'drift_time']`. Exactly these variables will be fixed to the passed values during simulation.
 - a dictionary with keys: `['x', 'y', 'z']` and/or `['r', 'theta', 'z']` and/or `event_time` and/or `energy` to set either position, time, energy or any combination thereof.

When passing the position of events in Cartesian format, the cylindrical coordinates are automatically calculated as well and vice versa. When passing the position, the drift time is recalculated since it depends on the depth.

