### PR TITLE
WIMPSource bugfix and test

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -879,7 +879,8 @@ class WIMPSource(NRSource):
         e = np.array([self.energy_hist.slicesum(t).histogram
                       for t in self.data['t']])
         energy_tensor = tf.convert_to_tensor(e, dtype=fd.float_type())
-        assert energy_tensor.shape == [len(self.data), e_bin_centers]
+        assert energy_tensor.shape == [len(self.data), len(e_bin_centers)], \
+            f"{energy_tensor.shape} != {len(self.data)}, {len(e_bin_centers)}"
         self.energy_tensor = tf.reshape(energy_tensor,
                                         [self.n_batches, self.batch_size, -1])
 

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -815,7 +815,8 @@ class WIMPSource(NRSource):
         times = np.linspace(wr.j2000(date=self.t_start),
                             wr.j2000(date=self.t_stop), self.n_in)
         time_centers = self.bin_centers(times)
-        es_centers = self.bin_centers(self.es)
+        es = self.es  # TODO, rewrite init
+        es_centers = self.bin_centers(es)
 
         if wimp_kwargs is None:
             # Use default mass, xsec and energy range instead

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -815,7 +815,7 @@ class WIMPSource(NRSource):
         times = np.linspace(wr.j2000(date=self.t_start),
                             wr.j2000(date=self.t_stop), self.n_in)
         time_centers = self.bin_centers(times)
-        es_centers = self.bin_centers(es)
+        es_centers = self.bin_centers(self.es)
 
         if wimp_kwargs is None:
             # Use default mass, xsec and energy range instead

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -815,34 +815,28 @@ class WIMPSource(NRSource):
         times = np.linspace(wr.j2000(date=self.t_start),
                             wr.j2000(date=self.t_stop), self.n_in)
         time_centers = self.bin_centers(times)
-        es = self.es  # TODO, rewrite init
-        es_centers = self.bin_centers(es)
 
         if wimp_kwargs is None:
-            # Use default mass, xsec and energy range instead
+            # No arguments given at all;
+            # use default mass, xsec and energy range
             wimp_kwargs = dict(mw=self.mw,
                                sigma_nucleon=self.sigma_nucleon,
-                               es=es_centers)
+                               es=self.es)
         else:
-            # Pass dict with settings for wimprates
             assert 'mw' in wimp_kwargs and 'sigma_nucleon' in wimp_kwargs, \
                 "Pass at least 'mw' and 'sigma_nucleon' in wimp_kwargs"
-            if 'es' in wimp_kwargs:
-                # Optionally also pass a new energy range
-                # This should be the np.geomspace, not the bin centers
-                # which we compute here.
-                # How to assert this?
-                es = wimp_kwargs['es']
-                es_centers = self.bin_centers(es)
-                wimp_kwargs['es'] = es_centers
-            else:
-                # Otherwise use the default
-                wimp_kwargs['es'] = es_centers
+            if 'es' not in wimp_kwargs:
+                # Energies not given, use default energy bin edges
+                wimp_kwargs['es'] = self.es
 
-        es_diff = np.diff(es)
+        es = wimp_kwargs['es']
+        es_centers = self.bin_centers(es)
+        del wimp_kwargs['es']  # To avoid confusion centers / edges
 
-        assert len(es_diff) == len(es_centers)
-        spectra = np.array([wr.rate_wimp_std(t=t, **wimp_kwargs) * es_diff
+        # Transform wimp_kwargs to arguments that can be passed to wimprates
+        # which means transforming es from edges to centers
+        spectra = np.array([wr.rate_wimp_std(t=t, es=es_centers, **wimp_kwargs)
+                            * np.diff(es)
                             for t in time_centers])
         assert spectra.shape == (len(time_centers), len(es_centers))
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -30,9 +30,11 @@ n_events = 2
 def xes(request):
     # warnings.filterwarnings("error")
     data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
-                              x=2., y=0.4, z=-20, r=2.1, theta=0.1),
+                              x=2., y=0.4, z=-20, r=2.1, theta=0.1,
+                              event_time=1483488000000000000),
                          dict(s1=23, s2=1080., drift_time=445622.,
-                              x=1.12, y=0.35, z=-59., r=1., theta=0.3)])
+                              x=1.12, y=0.35, z=-59., r=1., theta=0.3,
+                              event_time=1483488000000000000)])
     if request.param == 'ER':
         x = fd.ERSource(data.copy(), batch_size=2, max_sigma=8)
     elif request.param == 'NR':

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -26,7 +26,7 @@ def np_lookup_axis1(x, indices, fill_value=0):
 
 n_events = 2
 
-@pytest.fixture(params=["ER", "NR", "ER_spatial"])
+@pytest.fixture(params=["ER", "NR", "ER_spatial", "WIMP"])
 def xes(request):
     # warnings.filterwarnings("error")
     data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
@@ -37,6 +37,8 @@ def xes(request):
         x = fd.ERSource(data.copy(), batch_size=2, max_sigma=8)
     elif request.param == 'NR':
         x = fd.NRSource(data.copy(), batch_size=2, max_sigma=8)
+    elif request.param == 'WIMP':
+        x = fd.WIMPSource(data.copy(), batch_size=2, max_sigma=8)
     elif request.param == 'ER_spatial':
         nbins = 100
         r = np.linspace(0, 47.9, nbins + 1)


### PR DESCRIPTION
This fixes a bug introduced in PR #30 where `self.es` had been removed in too many places. This bug was not caught by our tests since `WIMPSource` is not tested against.

 * I've added a quick fix which solves the immediate problem. But we should rewrite the `WIMPSource.__init__` since it's not so well designed at the moment. I've opened issue #32  for this.

 * I've added `WIMPSource` to the pytest fixture in `test_source.py` so that it also runs our source tests.