### PR TITLE
Update sr1 ER and NRSource, fix bugs and usage of ColumnSource

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -100,6 +100,8 @@ class LogLikelihood:
         for pname in common_param_specs:
             # Check defaults for common parameters are consistent between
             # sources
+            if pname not in s.defaults:
+                continue
             defs = [s.defaults[pname] for s in self.sources.values()]
             if len(set([x.numpy() for x in defs])) > 1:
                 raise ValueError(

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -100,9 +100,9 @@ class LogLikelihood:
         for pname in common_param_specs:
             # Check defaults for common parameters are consistent between
             # sources
-            if pname not in s.defaults:
-                continue
-            defs = [s.defaults[pname] for s in self.sources.values()]
+            defs = [s.defaults[pname]
+                    for s in self.sources.values()
+                    if pname in s.defaults]
             if len(set([x.numpy() for x in defs])) > 1:
                 raise ValueError(
                     f"Inconsistent defaults {defs} for common parameters")

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -57,7 +57,7 @@ class ColumnSource(SourceBase):
     mu = 42.
 
     def __init__(self,
-                 data,
+                 data=None,
                  batch_size=10,
                  max_sigma=3,
                  data_is_annotated=False,

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -85,7 +85,7 @@ class ColumnSource(SourceBase):
         else:
             self._init_padding(batch_size, _skip_tf_init)
             self.data_tensor = fd.np_to_tf(self.data[self.column])
-            self.data_tensor = tf.reshape(self.data_tensor, (self.batch_size, -1, 1))
+            self.data_tensor = tf.reshape(self.data_tensor, ( -1,self.batch_size, 1))
 
     def differential_rate(self, data_tensor, **params):
         return data_tensor[:, 0]

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -76,7 +76,7 @@ class ColumnSource(SourceBase):
         :param fit_params: List of parameters to fit
         :param params: New defaults
         """
-        self.params = dict()
+        self.defaults = dict()
         self.data = data
 
         self._init_padding(batch_size, _skip_tf_init)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -78,11 +78,14 @@ class ColumnSource(SourceBase):
         """
         self.defaults = dict()
         self.data = data
-
-        self._init_padding(batch_size, _skip_tf_init)
-
-        self.data_tensor = fd.np_to_tf(self.data[self.column])
-        self.data_tensor = tf.reshape(self.data_tensor, (self.batch_size, -1, 1))
+        if data is None:
+            # We're calling the source without data. Set the batch_size here
+            # since we can't pass it to set_data later
+            self.batch_size = batch_size
+        else:
+            self._init_padding(batch_size, _skip_tf_init)
+            self.data_tensor = fd.np_to_tf(self.data[self.column])
+            self.data_tensor = tf.reshape(self.data_tensor, (self.batch_size, -1, 1))
 
     def differential_rate(self, data_tensor, **params):
         return data_tensor[:, 0]

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -76,6 +76,7 @@ class ColumnSource(SourceBase):
         :param fit_params: List of parameters to fit
         :param params: New defaults
         """
+        self.params = dict()
         self.data = data
 
         self._init_padding(batch_size, _skip_tf_init)

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -29,11 +29,22 @@ s1_map, s2_map = [
 
 
 @export
-class SR1Source(fd.ERSource):
+class SR1Source:
     drift_velocity = 1.335 * 1e-4   # cm/ns
     extra_needed_columns = tuple(
         list(fd.ERSource.extra_needed_columns)
         + ['x_observed', 'y_observed'])
+
+    def random_truth(self, energies, fix_truth=None, **params):
+        d = super().random_truth(energies, fix_truth=fix_truth, **params)
+
+        # Add extra needed columns
+        # TODO: Add FDC maps instead of posrec resolution
+        d['x_observed'] = np.random.normal(d['x'].values,
+                                           scale=2)  # 2cm resolution)
+        d['y_observed'] = np.random.normal(d['y'].values,
+                                           scale=2)  # 2cm resolution)
+        return d
 
     @staticmethod
     def add_extra_columns(d):
@@ -104,4 +115,10 @@ class SR1ERSource(SR1Source,fd.ERSource):
                         tf.zeros_like(s2, dtype=fd.float_type()),
                         tf.ones_like(s2, dtype=fd.float_type()))
 
-#TODO: add NRsource
+class SR1NRSource(SR1Source, fd.NRSource):
+    extra_needed_columns = tuple(set(
+        list(SR1Source.extra_needed_columns) + 
+        list(fd.NRSource.extra_needed_columns)+
+        ['x_observed', 'y_observed']))
+
+# TODO: Modify the SR1NRSource to fit AmBe data better and add WIMPSource

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -35,8 +35,8 @@ class SR1Source:
         list(fd.ERSource.extra_needed_columns)
         + ['x_observed', 'y_observed'])
 
-    def random_truth(self, energies, fix_truth=None, **params):
-        d = super().random_truth(energies, fix_truth=fix_truth, **params)
+    def random_truth(self, n_events, fix_truth=None, **params):
+        d = super().random_truth(n_events, fix_truth=fix_truth, **params)
 
         # Add extra needed columns
         # TODO: Add FDC maps instead of posrec resolution
@@ -118,7 +118,6 @@ class SR1ERSource(SR1Source,fd.ERSource):
 class SR1NRSource(SR1Source, fd.NRSource):
     extra_needed_columns = tuple(set(
         list(SR1Source.extra_needed_columns) + 
-        list(fd.NRSource.extra_needed_columns)+
-        ['x_observed', 'y_observed']))
+        list(fd.NRSource.extra_needed_columns)))
 
 # TODO: Modify the SR1NRSource to fit AmBe data better and add WIMPSource


### PR DESCRIPTION
In this pull request a few key features were fixed and updated:

- In the x1t_sr1.py the SR1Source was updated to take random_truth, which makes ERSource usable again
- The NRSource was added and takes also the extra needed columns of 'x_observed' and 'y_observed' from the correction maps #29 
- The use of ColumnSource was checked and a few bugs were fixed:
   - defaults were added to the initialisation of the source
   - the source can be initialised with data = None
   - an important bug was fixed in the shape of data given to the source, where the number of batches was given instead of the batch size #33 

Work to be done: 
Update the NRSource model to fit the AmBe data better and possibly update the defaults of it.